### PR TITLE
PR 発行時に Discord へ通知

### DIFF
--- a/.github/workflows/discord-pr-notification.yaml
+++ b/.github/workflows/discord-pr-notification.yaml
@@ -1,0 +1,27 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [opened] # PRがオープンされた時のみ実行
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        # tsickert/discord-webhook アクションを使用
+        uses: tsickert/discord-webhook@v7.0.0
+        with:
+          # Secretsに設定したWebhook URL
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          username: GitHub
+          avatar-url: ${{ vars.DISCORD_WEBHOOK_ICON_URL }}
+
+          # --- embed の内容をここで定義 ---
+          embed-title: "#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}"
+          embed-description: "${{ github.event.pull_request.body }}"
+          embed-url: "${{ github.event.pull_request.html_url }}"
+          embed-author-name: "${{ github.event.pull_request.user.login }}"
+          embed-author-url: "${{ github.event.pull_request.user.html_url }}"
+          embed-author-icon-url: "${{ github.event.pull_request.user.avatar_url }}"
+          embed-timestamp: "${{ github.event.pull_request.created_at }}"


### PR DESCRIPTION
## 変更内容

- PR の発行時に Discord へ Webhook を送信する Workflow を作成

## なぜこの変更が必要か

- GitHub 標準機能の Webhook では、PR のクローズ通知まで含まれてしまい、目障りである
- 手動で Workflow を作成することで、細かく通知タイミングを調整することができる

## 変更の検証方法

1. この PR の発行時に Discord に内容が通知されるはず

## スクリーンショット/デモ

<img width="592" height="640" alt="image" src="https://github.com/user-attachments/assets/fe036a91-1035-4b8f-9324-288f02c755ca" />

## チェックリスト

- [x] コードがプロジェクトのコーディング規約に従っているか
- [x] 新しいテストが追加されたか、または既存のテストがパスしているか
- [x] セルフレビューを行ったか