### PR TITLE
Discord への通知から Pull Request の本文を削除

### DIFF
--- a/.github/workflows/discord-pr-notification.yaml
+++ b/.github/workflows/discord-pr-notification.yaml
@@ -19,7 +19,6 @@ jobs:
 
           # --- embed の内容をここで定義 ---
           embed-title: "#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}"
-          embed-description: "${{ github.event.pull_request.body }}"
           embed-url: "${{ github.event.pull_request.html_url }}"
           embed-author-name: "${{ github.event.pull_request.user.login }}"
           embed-author-url: "${{ github.event.pull_request.user.html_url }}"


### PR DESCRIPTION
## 変更内容

- PR 発行時の Discord への通知について、PR の本文を削除

## なぜこの変更が必要か

- 文章が長い PR (特に Dependabot) の際に、Discord に長文が送られて目障りである

## 変更の検証方法

1. この PR の本文が Discord に表示されていなければ OK

## スクリーンショット/デモ

<img width="600" height="177" alt="image" src="https://github.com/user-attachments/assets/15e54dcb-9a6e-4420-9ce5-6ace866491fd" />

## チェックリスト

- [x] コードがプロジェクトのコーディング規約に従っているか
- [x] 新しいテストが追加されたか、または既存のテストがパスしているか
- [x] ドキュメントが更新されたか (必要な場合)
- [x] セルフレビューを行ったか

## レビュアーへの特記事項

特になし
