### PR TITLE
implement group-creation on create-group page

### DIFF
--- a/src/app/(auth)/create-group/actions.ts
+++ b/src/app/(auth)/create-group/actions.ts
@@ -6,10 +6,15 @@ import { userGroupAdminRepo } from "@/infra/group/user-group-admin-repository";
 import type { ServiceError } from "@/domain/error";
 import { requireAuth } from "@/lib/auth/server-auth";
 
+interface ActionError {
+    message: string;
+    code?: string;
+}
+
 export async function createGroupAction(
     name: string,
 ): Promise<
-    { success: true; groupId: string } | { success: false; error: string }
+    { success: true; groupId: string } | { success: false; error: ActionError }
 > {
     const decodedClaims = await requireAuth();
     const userId = decodedClaims.uid;
@@ -23,6 +28,12 @@ export async function createGroupAction(
 
     return result.match(
         (group) => ({ success: true, groupId: group.id }),
-        (err: ServiceError) => ({ success: false, error: err.message }),
+        (err: ServiceError) => ({
+            success: false,
+            error: {
+                message: err.message,
+                code: "extra" in err ? err.extra?.code : undefined,
+            },
+        }),
     );
 }

--- a/src/app/(auth)/create-group/page.tsx
+++ b/src/app/(auth)/create-group/page.tsx
@@ -28,7 +28,7 @@ const CreateGroupPage = () => {
                 router.push("/group");
             } else {
                 toast.error("グループの作成に失敗しました", {
-                    description: result.error,
+                    description: result.error.message,
                 });
             }
         } catch {


### PR DESCRIPTION
## 関連する Issue

- #207 

## 変更内容

- create-group pageでgroup nameを入力して追加するとDBにデータを追加

## なぜこの変更が必要か

- DBにgroup dataを追加するため

## 変更の検証方法

1.

## スクリーンショット/デモ
<img width="2255" height="1264" alt="image" src="https://github.com/user-attachments/assets/d115bb8b-59f3-4ea6-8d9f-a1e457beba89" />


## チェックリスト

- [ ] 関連する Issue へのリンクが記述されているか
- [ ] コードがプロジェクトのコーディング規約に従っているか
- [ ] 新しいテストが追加されたか、または既存のテストがパスしているか
- [ ] ドキュメントが更新されたか (必要な場合)
- [ ] セルフレビューを行ったか

## レビュアーへの特記事項

Close #207 
group/page.tsx ではgaccountのユーザー名ではなく、アドレス自体がdisplayNameとして表示されています。別PRで対応？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a group creation form with input field and submit button
  * Implemented real-time form state management with visual feedback during submission
  * Added toast notifications to confirm successful group creation or display errors
  * Automatic navigation to the newly created group page upon completion
  * Form inputs are disabled during submission to prevent accidental duplicate submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->