### PR TITLE
fix: createSlots に時間帯フィルタを追加し深夜スロット生成を抑制

### DIFF
--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -13,6 +13,10 @@ import { getScheduleSuggestionsAction } from "./actions";
 
 type User = { id: string; username: string; email: string };
 
+// TODO: このリストは src/domain/event.ts の EVENT_TIME_OF_DAY_CONFIG と重複している。
+// 時間帯を追加・変更する場合は EVENT_TIME_OF_DAY_CONFIG を更新したうえで、
+// このファイルと EditEventClient.tsx の timeOfDayInputItems も合わせて更新すること。
+// 将来的には EVENT_TIME_OF_DAY_CONFIG から直接導出するよう統一を検討。
 const timeOfDayInputItems: { value: EventTimeOfDay; label: string }[] = [
     { value: "morning", label: "朝（8:00~12:00ごろ）" },
     { value: "noon", label: "昼（12:00~15:00ごろ）" },

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -3,7 +3,7 @@
 import { requireAuth } from "@/lib/auth/server-auth";
 import { userGroupAdminRepo } from "@/infra/group/user-group-admin-repository";
 import { firestoreEventAdminRepository } from "@/infra/event/event-admin-repo";
-import type { EventDraft, NewEvent } from "@/domain/event";
+import type { EventDraft, EventTimeOfDay, NewEvent } from "@/domain/event";
 import { EVENT_TIME_OF_DAY_CONFIG } from "@/domain/event";
 import { revalidatePath } from "next/cache";
 import { parseDuration } from "@/lib/event-to-draft";
@@ -86,10 +86,15 @@ export async function getScheduleSuggestionsAction(
         const scheduleRange = { start: tomorrow, end: rangeEnd };
 
         // UI の timeOfDayCandidate（morning/noon/evening/night）を
-        // JST の時刻範囲に変換し、スロット生成時のフィルタとして渡す
+        // JST の時刻範囲に変換し、スロット生成時のフィルタとして渡す。
+        // ランタイムでフォームデータに無効値が混入する可能性に備え、
+        // EVENT_TIME_OF_DAY_CONFIG に存在するキーのみ使用する。
+        const validCandidates = draft.timeOfDayCandidate.filter(
+            (t): t is EventTimeOfDay => t in EVENT_TIME_OF_DAY_CONFIG,
+        );
         const allowedHourRanges =
-            draft.timeOfDayCandidate.length > 0
-                ? draft.timeOfDayCandidate.map(
+            validCandidates.length > 0
+                ? validCandidates.map(
                       (t) => EVENT_TIME_OF_DAY_CONFIG[t].hours,
                   )
                 : undefined;
@@ -115,10 +120,10 @@ export async function getScheduleSuggestionsAction(
 
         const requiredCount = members.filter((m) => m.isRequired).length;
 
-        // AIプロンプト用の時間帯ラベルも EVENT_TIME_OF_DAY_CONFIG から導出
+        // AIプロンプト用の時間帯ラベルも検証済みの validCandidates から導出
         const timeConstraint =
-            draft.timeOfDayCandidate.length > 0
-                ? `\n希望時間帯: ${draft.timeOfDayCandidate.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].label).join("、")}`
+            validCandidates.length > 0
+                ? `\n希望時間帯: ${validCandidates.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].label).join("、")}`
                 : "";
         const descriptionWithTimeConstraint =
             draft.description + timeConstraint;

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -94,9 +94,7 @@ export async function getScheduleSuggestionsAction(
         );
         const allowedHourRanges =
             validCandidates.length > 0
-                ? validCandidates.map(
-                      (t) => EVENT_TIME_OF_DAY_CONFIG[t].hours,
-                  )
+                ? validCandidates.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].hours)
                 : undefined;
 
         const scoresResult = await createCalculateFreeTimeService(

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -4,6 +4,7 @@ import { requireAuth } from "@/lib/auth/server-auth";
 import { userGroupAdminRepo } from "@/infra/group/user-group-admin-repository";
 import { firestoreEventAdminRepository } from "@/infra/event/event-admin-repo";
 import type { EventDraft, NewEvent } from "@/domain/event";
+import { EVENT_TIME_OF_DAY_CONFIG } from "@/domain/event";
 import { revalidatePath } from "next/cache";
 import { parseDuration } from "@/lib/event-to-draft";
 import { findUsersByIds } from "@/infra/user/user-admin-repo";
@@ -84,10 +85,24 @@ export async function getScheduleSuggestionsAction(
 
         const scheduleRange = { start: tomorrow, end: rangeEnd };
 
+        // UI の timeOfDayCandidate（morning/noon/evening/night）を
+        // JST の時刻範囲に変換し、スロット生成時のフィルタとして渡す
+        const allowedHourRanges =
+            draft.timeOfDayCandidate.length > 0
+                ? draft.timeOfDayCandidate.map(
+                      (t) => EVENT_TIME_OF_DAY_CONFIG[t].hours,
+                  )
+                : undefined;
+
         const scoresResult = await createCalculateFreeTimeService(
             googleCalendarRepository,
             googleTokenRepository,
-        ).calculateFreeTime(scheduleRange, durationMinutes, members);
+        ).calculateFreeTime(
+            scheduleRange,
+            durationMinutes,
+            members,
+            allowedHourRanges,
+        );
 
         if (scoresResult.isErr()) {
             return {
@@ -100,15 +115,10 @@ export async function getScheduleSuggestionsAction(
 
         const requiredCount = members.filter((m) => m.isRequired).length;
 
-        const timeOfDayLabels: Record<string, string> = {
-            morning: "朝（8:00〜12:00ごろ）",
-            noon: "昼（12:00〜15:00ごろ）",
-            evening: "夕（15:00〜18:00ごろ）",
-            night: "夜（18:00〜22:00ごろ）",
-        };
+        // AIプロンプト用の時間帯ラベルも EVENT_TIME_OF_DAY_CONFIG から導出
         const timeConstraint =
             draft.timeOfDayCandidate.length > 0
-                ? `\n希望時間帯: ${draft.timeOfDayCandidate.map((t) => timeOfDayLabels[t] ?? t).join("、")}`
+                ? `\n希望時間帯: ${draft.timeOfDayCandidate.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].label).join("、")}`
                 : "";
         const descriptionWithTimeConstraint =
             draft.description + timeConstraint;

--- a/src/app/(auth)/edit-event/EditEventClient.tsx
+++ b/src/app/(auth)/edit-event/EditEventClient.tsx
@@ -11,6 +11,10 @@ import { convertEventToDraft } from "@/lib/event-to-draft";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { updateEventAction, deleteEventAction } from "./actions";
 
+// TODO: このリストは src/domain/event.ts の EVENT_TIME_OF_DAY_CONFIG と重複している。
+// 時間帯を追加・変更する場合は EVENT_TIME_OF_DAY_CONFIG を更新したうえで、
+// このファイルと CreateEventForm.tsx の timeOfDayInputItems も合わせて更新すること。
+// 将来的には EVENT_TIME_OF_DAY_CONFIG から直接導出するよう統一を検討。
 const timeOfDayInputItems: {
     value: EventTimeOfDay;
     label: string;
@@ -21,6 +25,8 @@ const timeOfDayInputItems: {
     { value: "night", label: "夜（18:00~22:00ごろ）" },
 ];
 
+// TODO: 以下の開始時刻は EVENT_TIME_OF_DAY_CONFIG の hours.start と重複している。
+// 将来的には EVENT_TIME_OF_DAY_CONFIG[時間帯].hours.start を直接参照するよう統一を検討。
 const timeOfDayHours: Record<EventTimeOfDay, number> = {
     morning: 8,
     noon: 12,

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -41,29 +41,23 @@ describe("createSlots", () => {
         // UTC 15:00 = JST 0:00 から UTC 翌日 15:00 = JST 翌日 0:00 まで（24時間）
         const timeRange = {
             start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
-            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"), // JST 2/28 0:00
         };
         // 朝（JST 8:00〜12:00）のみ許可 → UTC 23:00〜03:00 のスロットだけ残る
-        const result = createSlots(timeRange, 60, 60, [
-            { start: 8, end: 12 },
-        ]);
+        const result = createSlots(timeRange, 60, 60, [{ start: 8, end: 12 }]);
 
         // JST 8:00, 9:00, 10:00, 11:00 の4スロット（duration=60分, interval=60分）
         expect(result).toHaveLength(4);
         // 最初のスロット: UTC 23:00 = JST 8:00
-        expect(result[0].start.toISOString()).toBe(
-            "2026-02-26T23:00:00.000Z",
-        );
+        expect(result[0].start.toISOString()).toBe("2026-02-26T23:00:00.000Z");
         // 最後のスロット: UTC 02:00 = JST 11:00
-        expect(result[3].start.toISOString()).toBe(
-            "2026-02-27T02:00:00.000Z",
-        );
+        expect(result[3].start.toISOString()).toBe("2026-02-27T02:00:00.000Z");
     });
 
     it("should filter slots by multiple allowedHourRanges (morning + night)", () => {
         const timeRange = {
             start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
-            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"), // JST 2/28 0:00
         };
         // 朝（8〜12）と夜（18〜22）を許可
         const result = createSlots(timeRange, 60, 60, [
@@ -85,7 +79,7 @@ describe("createSlots", () => {
     it("should generate all slots when allowedHourRanges is undefined", () => {
         const timeRange = {
             start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
-            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"), // JST 2/28 0:00
         };
         const withFilter = createSlots(timeRange, 60, 60, undefined);
         const withoutFilter = createSlots(timeRange, 60, 60);

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -36,6 +36,64 @@ describe("createSlots", () => {
         const result = createSlots(timeRange, 60, 30);
         expect(result).toHaveLength(0);
     });
+
+    it("should filter slots by single allowedHourRanges (morning only)", () => {
+        // UTC 15:00 = JST 0:00 から UTC 翌日 15:00 = JST 翌日 0:00 まで（24時間）
+        const timeRange = {
+            start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+        };
+        // 朝（JST 8:00〜12:00）のみ許可 → UTC 23:00〜03:00 のスロットだけ残る
+        const result = createSlots(timeRange, 60, 60, [
+            { start: 8, end: 12 },
+        ]);
+
+        // JST 8:00, 9:00, 10:00, 11:00 の4スロット（duration=60分, interval=60分）
+        expect(result).toHaveLength(4);
+        // 最初のスロット: UTC 23:00 = JST 8:00
+        expect(result[0].start.toISOString()).toBe(
+            "2026-02-26T23:00:00.000Z",
+        );
+        // 最後のスロット: UTC 02:00 = JST 11:00
+        expect(result[3].start.toISOString()).toBe(
+            "2026-02-27T02:00:00.000Z",
+        );
+    });
+
+    it("should filter slots by multiple allowedHourRanges (morning + night)", () => {
+        const timeRange = {
+            start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+        };
+        // 朝（8〜12）と夜（18〜22）を許可
+        const result = createSlots(timeRange, 60, 60, [
+            { start: 8, end: 12 },
+            { start: 18, end: 22 },
+        ]);
+
+        // 朝4スロット + 夜4スロット = 8スロット
+        expect(result).toHaveLength(8);
+        // 全スロットが朝 or 夜の時間帯に含まれることを検証
+        for (const slot of result) {
+            const hourJST = (slot.start.getUTCHours() + 9) % 24;
+            const inMorning = hourJST >= 8 && hourJST < 12;
+            const inNight = hourJST >= 18 && hourJST < 22;
+            expect(inMorning || inNight).toBe(true);
+        }
+    });
+
+    it("should generate all slots when allowedHourRanges is undefined", () => {
+        const timeRange = {
+            start: new Date("2026-02-26T15:00:00.000Z"), // JST 2/27 0:00
+            end: new Date("2026-02-27T15:00:00.000Z"),   // JST 2/28 0:00
+        };
+        const withFilter = createSlots(timeRange, 60, 60, undefined);
+        const withoutFilter = createSlots(timeRange, 60, 60);
+
+        // undefined を渡した場合と省略した場合で同じ結果
+        expect(withFilter).toHaveLength(withoutFilter.length);
+        expect(withFilter).toHaveLength(24);
+    });
 });
 
 describe("calculateTimeRangeScores", () => {

--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -4,6 +4,21 @@ import { DBError } from "./error";
 export const eventTimeOfDays = ["morning", "noon", "evening", "night"] as const;
 export type EventTimeOfDay = (typeof eventTimeOfDays)[number];
 
+/**
+ * 時間帯ごとのラベルと時刻範囲（JST）の一元定義。
+ * UI表示・AIプロンプト生成・スロットフィルタリングすべてがここを参照する。
+ * 新しい時間帯を追加する場合は、eventTimeOfDays とこのオブジェクトの両方にエントリを追加すること。
+ */
+export const EVENT_TIME_OF_DAY_CONFIG: Record<
+    EventTimeOfDay,
+    { label: string; hours: { start: number; end: number } }
+> = {
+    morning: { label: "朝（8:00〜12:00ごろ）", hours: { start: 8, end: 12 } },
+    noon: { label: "昼（12:00〜15:00ごろ）", hours: { start: 12, end: 15 } },
+    evening: { label: "夕（15:00〜18:00ごろ）", hours: { start: 15, end: 18 } },
+    night: { label: "夜（18:00〜22:00ごろ）", hours: { start: 18, end: 22 } },
+};
+
 // AI提案前のユーザー入力データ
 export interface EventDraft {
     title: string;

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -32,6 +32,9 @@ export interface TimeRangeScore {
  * @param timeRange 時間帯
  * @param durationMinutes スロットの長さ（分）
  * @param intervalMinutes スロットの開始時刻の間隔（分）
+ * @param allowedHourRanges 許可する時間帯（JST）の配列。指定時、開始時刻がいずれの範囲にも
+ *                          含まれないスロットは生成しない。未指定の場合は全時間帯を対象とする。
+ *                          各範囲は [start, end) で半開区間。例: { start: 8, end: 12 } → 8:00〜11:59
  * @returns タイムスロット
  *
  * @example
@@ -48,6 +51,7 @@ export const createSlots = (
     timeRange: TimeRange,
     durationMinutes: number,
     intervalMinutes: number,
+    allowedHourRanges?: { start: number; end: number }[],
 ): TimeRange[] => {
     if (durationMinutes <= 0) {
         throw new RangeError(
@@ -77,6 +81,21 @@ export const createSlots = (
             break;
         }
 
+        // 時間帯フィルタ: 指定されている場合、開始時刻（JST）がいずれかの
+        // 許可範囲に含まれるスロットのみ生成する
+        if (allowedHourRanges) {
+            const hourJST = (currentStart.getUTCHours() + 9) % 24;
+            const isAllowed = allowedHourRanges.some(
+                (range) => hourJST >= range.start && hourJST < range.end,
+            );
+            if (!isAllowed) {
+                currentStart = new Date(
+                    currentStart.getTime() + slotIntervalMs,
+                );
+                continue;
+            }
+        }
+
         slots.push({
             start: currentStart,
             end: currentEnd,
@@ -103,11 +122,13 @@ export const calculateTimeRangeScores = (
     memberAvailability: UserTimeRanges[],
     members: EventMember[],
     slotIntervalMinutes: number = 30,
+    allowedHourRanges?: { start: number; end: number }[],
 ): TimeRangeScore[] => {
     const slots: TimeRangeScore[] = createSlots(
         timeRange,
         durationMinutes,
         slotIntervalMinutes,
+        allowedHourRanges,
     ).map((slot) => ({
         timeRange: slot,
         availableMemberIds: {

--- a/src/service/calculate-free-time-service.ts
+++ b/src/service/calculate-free-time-service.ts
@@ -26,6 +26,7 @@ export interface CalculateFreeTimeService {
         scheduleRange: TimeRange,
         eventDurationMinutes: number,
         members: EventMember[],
+        allowedHourRanges?: { start: number; end: number }[],
     ): ResultAsync<TimeRangeScore[], CalendarError>;
 }
 
@@ -39,7 +40,7 @@ export const createCalculateFreeTimeService = (
     );
 
     return {
-        calculateFreeTime: (scheduleRange, eventDurationMinutes, members) =>
+        calculateFreeTime: (scheduleRange, eventDurationMinutes, members, allowedHourRanges) =>
             ResultAsync.combine(
                 members.map((user) =>
                     calendarService.fetchFreeSlots(
@@ -55,6 +56,15 @@ export const createCalculateFreeTimeService = (
                     eventDurationMinutes,
                     freeSlots,
                     members,
+                    // slotIntervalMinutes: undefined を渡して calculateTimeRangeScores の
+                    // デフォルト値（30分刻み）を使用。
+                    // TODO: 現状は30分固定だが、以下の方法で柔軟化を検討できる:
+                    //   案A: EventDraft に slotIntervalMinutes フィールドを追加し、UIから指定できるようにする
+                    //   案B: イベントの所要時間(eventDurationMinutes)に応じて自動調整する
+                    //        （例: 2時間以上なら60分刻み、30分未満なら15分刻み）
+                    //   案C: 現状の30分固定のまま運用し、必要になったときに対応する
+                    undefined,
+                    allowedHourRanges,
                 ),
             ),
     };

--- a/src/service/calculate-free-time-service.ts
+++ b/src/service/calculate-free-time-service.ts
@@ -63,11 +63,12 @@ export const createCalculateFreeTimeService = (
                     members,
                     // slotIntervalMinutes: undefined を渡して calculateTimeRangeScores の
                     // デフォルト値（30分刻み）を使用。
-                    // TODO: 現状は30分固定だが、以下の方法で柔軟化を検討できる:
+                    // TODO: 現状は30分固定で運用。柔軟化を検討する場合は以下を参照:
                     //   案A: EventDraft に slotIntervalMinutes フィールドを追加し、UIから指定できるようにする
                     //   案B: イベントの所要時間(eventDurationMinutes)に応じて自動調整する
-                    //        （例: 2時間以上なら60分刻み、30分未満なら15分刻み）
-                    //   案C: 現状の30分固定のまま運用し、必要になったときに対応する
+                    //        ただし刻みを大きくすると「13:30〜15:30は空いているのに60分刻みで
+                    //        スルーされる」問題が起きるため注意（PR #258 TITANdayo指摘）
+                    //   → 当面は30分固定を維持し、別Issueで検討する
                     undefined,
                     allowedHourRanges,
                 ),

--- a/src/service/calculate-free-time-service.ts
+++ b/src/service/calculate-free-time-service.ts
@@ -40,7 +40,12 @@ export const createCalculateFreeTimeService = (
     );
 
     return {
-        calculateFreeTime: (scheduleRange, eventDurationMinutes, members, allowedHourRanges) =>
+        calculateFreeTime: (
+            scheduleRange,
+            eventDurationMinutes,
+            members,
+            allowedHourRanges,
+        ) =>
             ResultAsync.combine(
                 members.map((user) =>
                     calendarService.fetchFreeSlots(


### PR DESCRIPTION
## 問題
scheduleRange（明日〜14日後）を30分刻みで全時間帯のスロットに分割していたため、深夜帯のスロットが大量に生成され、全員が空いている深夜帯がスコア上位を占有し、AIが深夜の候補ばかり提案してしまう不具合があった。
UIの時間帯チェックボックス（朝/昼/夕/夜）はAIプロンプトのテキストにのみ反映され、スロット生成・スコア計算には影響していなかった。

## 変更内容
- **event.ts**: \EVENT_TIME_OF_DAY_CONFIG\ を追加し、時間帯のラベルと時刻範囲(JST)を一元定義。**今回はサーバー側（actions.ts / calculate-free-time-service.ts / schedule-calculator.ts）のみこの定義を参照するよう統一。** UI側（CreateEventForm.tsx / EditEventClient.tsx）は既存のハードコードを維持し、TODOコメントで将来の統一を促す。
- **schedule-calculator.ts**: \createSlots\ に \llowedHourRanges\ パラメータ（配列型）を追加。開始時刻(JST)がいずれかの許可範囲に含まれないスロットは生成段階でスキップする。\calculateTimeRangeScores\ からもパススルーで渡す。
- **calculate-free-time-service.ts**: \calculateFreeTime\ のシグネチャに \llowedHourRanges\ を追加。\slotIntervalMinutes\ は \undefined\ を渡してデフォルト値（30分刻み）を使用。スロット間隔の柔軟化についてはTODOコメントに検討事項を記載。
- **actions.ts**: \EVENT_TIME_OF_DAY_CONFIG\ を参照して \llowedHourRanges\ を構築し \calculateFreeTime\ に渡す。\	imeOfDayCandidate\ はランタイム検証（CONFIG に存在するキーのみ使用）を追加。AIプロンプト用ラベルも同じCONFIGから導出。

## テスト
### テスト済み（自動テスト）
- \createSlots\ の単体テスト3ケースを追加:
  - 単一時間帯フィルタ（朝のみ）: 許可外スロットが除外されることを確認
  - 複数時間帯フィルタ（朝+夜）: 不連続な範囲が正しく機能することを確認
  - フィルタ未指定: 既存挙動（全スロット生成）が壊れていないことを確認
- 既存テスト含め全7テスト合格

### テスト対象外（手動確認推奨）
- \ctions.ts\ → \calculateFreeTime\ → \calculateTimeRangeScores\ の連結フロー（外部カレンダーAPIのモックが必要なため今回のスコープ外）
- UIチェックボックス → スロット生成への反映（E2Eテスト）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule suggestions now filter available meeting slots based on selected time-of-day preferences (morning, noon, evening, or night) for more relevant recommendations.

* **Tests**
  * Added comprehensive test coverage for time-of-day filtering functionality in schedule calculations, including multiple time ranges and timezone edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gdsc-osaka/lablink/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->