### PR TITLE
スケジュール希望条件のSchemaを追加

### DIFF
--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -3,6 +3,7 @@ import {
     createSlots,
     calculateTimeRangeScores,
     EventMember,
+    SchedulePreferenceSchema,
 } from "../schedule-calculator";
 import { UserTimeRanges } from "@/domain/calendar";
 
@@ -87,6 +88,60 @@ describe("createSlots", () => {
         // undefined を渡した場合と省略した場合で同じ結果
         expect(withFilter).toHaveLength(withoutFilter.length);
         expect(withFilter).toHaveLength(24);
+    });
+});
+
+describe("SchedulePreferenceSchema", () => {
+    it("should parse day and hour-range preferences", () => {
+        const result = SchedulePreferenceSchema.safeParse({
+            dayWeights: [
+                {
+                    dayOfWeek: "friday",
+                    reason: "飲み会なので金曜日が適しています。",
+                },
+            ],
+            hourRangeWeights: [
+                {
+                    startHour: 19,
+                    endHour: 22,
+                    reason: "飲み会なので19時から22時が適しています。",
+                },
+            ],
+            summary: "金曜日の19時から22時を優先します。",
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    it("should reject unsupported days of week", () => {
+        const result = SchedulePreferenceSchema.safeParse({
+            dayWeights: [
+                {
+                    dayOfWeek: "holiday",
+                    reason: "Invalid day.",
+                },
+            ],
+            hourRangeWeights: [],
+            summary: "Invalid preference.",
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject hour ranges where startHour is not smaller than endHour", () => {
+        const result = SchedulePreferenceSchema.safeParse({
+            dayWeights: [],
+            hourRangeWeights: [
+                {
+                    startHour: 22,
+                    endHour: 19,
+                    reason: "Invalid hour range.",
+                },
+            ],
+            summary: "Invalid preference.",
+        });
+
+        expect(result.success).toBe(false);
     });
 });
 

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -1,5 +1,6 @@
 import { TimeRange, UserTimeRanges } from "./calendar";
 import { User } from "./user";
+import * as z from "zod";
 
 /**
  * イベントの参加者情報
@@ -11,6 +12,82 @@ export interface EventMember extends User {
 
 export const MEMBER_REQUIRED_SCORE = 10;
 export const MEMBER_OPTIONAL_SCORE = 1;
+
+export const SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+] as const;
+
+export const SchedulePreferenceDayOfWeekSchema = z.enum(
+    SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES,
+);
+
+export const SchedulePreferenceReasonSchema = z.string().min(1).max(160);
+
+export const SchedulePreferenceDaySchema = z.object({
+    dayOfWeek: SchedulePreferenceDayOfWeekSchema.describe(
+        "Preferred day of week for the event.",
+    ),
+    reason: SchedulePreferenceReasonSchema.describe(
+        "Why this day of week fits the event description.",
+    ),
+});
+
+export const SchedulePreferenceHourRangeSchema = z
+    .object({
+        startHour: z
+            .number()
+            .int()
+            .min(0)
+            .max(23)
+            .describe(
+                "Start hour in JST. The range is [startHour, endHour). Must be smaller than endHour.",
+            ),
+        endHour: z
+            .number()
+            .int()
+            .min(1)
+            .max(24)
+            .describe(
+                "End hour in JST. The range is [startHour, endHour). Must be greater than startHour.",
+            ),
+        reason: SchedulePreferenceReasonSchema.describe(
+            "Why this JST hour range fits the event description.",
+        ),
+    })
+    .refine((range) => range.startHour < range.endHour, {
+        message: "startHour must be smaller than endHour",
+        path: ["endHour"],
+    });
+
+export const SchedulePreferenceSchema = z.object({
+    dayWeights: z.array(SchedulePreferenceDaySchema).min(0).max(7),
+    hourRangeWeights: z
+        .array(SchedulePreferenceHourRangeSchema)
+        .min(0)
+        .max(4)
+        .describe(
+            "Preferred JST hour ranges. Keep this to the main candidate ranges; split overnight ranges such as 22-2 into 22-24 and 0-2.",
+        ),
+    summary: z.string().min(1).max(240),
+});
+
+export type SchedulePreferenceDayOfWeek = z.infer<
+    typeof SchedulePreferenceDayOfWeekSchema
+>;
+
+export type SchedulePreferenceDay = z.infer<typeof SchedulePreferenceDaySchema>;
+
+export type SchedulePreferenceHourRange = z.infer<
+    typeof SchedulePreferenceHourRangeSchema
+>;
+
+export type SchedulePreference = z.infer<typeof SchedulePreferenceSchema>;
 
 /**
  * 時間帯ごとの参加可能なユーザーとスコア


### PR DESCRIPTION
## 概要

自然言語のイベント内容から、希望する曜日・時間帯を structured output として扱うための Zod schema を追加しました。

このPRでは schema とテストの追加のみを行い、既存のスロット作成・スコアリング・Geminiによる候補選定フローは変更していません。

## 変更内容

- `SchedulePreferenceSchema` を追加
- 希望曜日を `dayWeights` として表現
- 希望時間帯を JST の具体的な時間範囲 `hourRangeWeights` として表現
- `z.infer` により `SchedulePreference` 型を schema から導出
- schema の正常系・異常系テストを追加

## 補足

このPRは、今後以下のようなフローへ変更するための準備です。

```text
UI入力 → Geminiで希望曜日・時間帯を抽出 → スロット作成 → スコアリング → 候補提示
```
実際に Gemini の出力をスコアリングへ反映する処理は、別PRで対応予定です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced schedule preference validation supporting day-of-week and hour-range specifications with built-in constraint enforcement (valid time ranges, supported day values).

* **Tests**
  * Added comprehensive test coverage for schedule preference validation including success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->