### PR TITLE
イベント削除ボタンをedit-eventからgroupへ移動

### DIFF
--- a/src/app/(auth)/edit-event/EditEventClient.tsx
+++ b/src/app/(auth)/edit-event/EditEventClient.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { convertEventToDraft } from "@/lib/event-to-draft";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { updateEventAction, deleteEventAction } from "./actions";
+import { updateEventAction } from "./actions";
 
 // TODO: このリストは src/domain/event.ts の EVENT_TIME_OF_DAY_CONFIG と重複している。
 // 時間帯を追加・変更する場合は EVENT_TIME_OF_DAY_CONFIG を更新したうえで、
@@ -94,25 +94,6 @@ const EditEventClient = ({ event, groupId }: Props) => {
         } catch (err) {
             console.error("Failed to update event:", err);
             setError("イベントの保存中にエラーが発生しました");
-        } finally {
-            setIsSubmitting(false);
-        }
-    };
-
-    const handleDelete = async () => {
-        if (!confirm("このイベントを削除しますか？")) return;
-        setError(null);
-        setIsSubmitting(true);
-        try {
-            const result = await deleteEventAction(groupId, event.id);
-            if (result.success) {
-                router.push("/group");
-            } else {
-                setError(result.error);
-            }
-        } catch (err) {
-            console.error("Failed to delete event:", err);
-            setError("イベントの削除中にエラーが発生しました");
         } finally {
             setIsSubmitting(false);
         }
@@ -265,16 +246,7 @@ const EditEventClient = ({ event, groupId }: Props) => {
                     )}
 
                     {/* ボタンエリア */}
-                    <div className="flex justify-between pt-6">
-                        <Button
-                            type="button"
-                            onClick={handleDelete}
-                            disabled={isSubmitting}
-                            className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            イベントを削除
-                        </Button>
-
+                    <div className="flex justify-end pt-6">
                         <Button
                             type="submit"
                             disabled={isSubmitting}

--- a/src/app/(auth)/edit-event/actions.ts
+++ b/src/app/(auth)/edit-event/actions.ts
@@ -1,28 +1,10 @@
 "use server";
 
 import { requireAuth } from "@/lib/auth/server-auth";
-import { userGroupAdminRepo } from "@/infra/group/user-group-admin-repository";
 import { firestoreEventAdminRepository } from "@/infra/event/event-admin-repo";
 import type { Event } from "@/domain/event";
 import { revalidatePath } from "next/cache";
-
-async function authorizeGroupMember(
-    groupId: string,
-    userId: string,
-): Promise<{ authorized: true } | { authorized: false; error: string }> {
-    const memberIdsResult =
-        await userGroupAdminRepo.getUserIdsByGroupId(groupId);
-    if (memberIdsResult.isErr()) {
-        return { authorized: false, error: "グループ情報の取得に失敗しました" };
-    }
-    if (!memberIdsResult.value.includes(userId)) {
-        return {
-            authorized: false,
-            error: "このグループへのアクセス権限がありません",
-        };
-    }
-    return { authorized: true };
-}
+import { authorizeGroupMember } from "@/app/(auth)/group/actions";
 
 export async function updateEventAction(
     groupId: string,
@@ -37,29 +19,6 @@ export async function updateEventAction(
     const result = await firestoreEventAdminRepository.updateNewEvent(
         groupId,
         event,
-    );
-    return result.match(
-        () => {
-            revalidatePath("/group");
-            return { success: true as const };
-        },
-        (err) => ({ success: false, error: err.message }),
-    );
-}
-
-export async function deleteEventAction(
-    groupId: string,
-    eventId: string,
-): Promise<{ success: true } | { success: false; error: string }> {
-    const decodedClaims = await requireAuth();
-    const auth = await authorizeGroupMember(groupId, decodedClaims.uid);
-    if (!auth.authorized) {
-        return { success: false, error: auth.error };
-    }
-
-    const result = await firestoreEventAdminRepository.deleteNewEvent(
-        groupId,
-        eventId,
     );
     return result.match(
         () => {

--- a/src/app/(auth)/group/_components/delete-event-button.tsx
+++ b/src/app/(auth)/group/_components/delete-event-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { deleteEventAction } from "../actions";
+
+type DeleteEventButtonProps = {
+    id: string;
+    groupId: string;
+};
+
+export default function DeleteEventButton({
+    id,
+    groupId,
+}: DeleteEventButtonProps) {
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const handleDelete = async () => {
+        if (!confirm("このイベントを削除しますか？")) return;
+        setIsDeleting(true);
+        setError(null);
+        try {
+            const result = await deleteEventAction(groupId, id);
+            if (!result.success) {
+                setError(result.error);
+                setIsDeleting(false);
+            }
+        } catch (err) {
+            console.error("Failed to delete event:", err);
+            setError("削除エラー");
+            setIsDeleting(false);
+        }
+    };
+
+    return (
+        <div className="flex flex-col items-center w-full">
+            <Button
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="w-full bg-red-500 hover:bg-red-700 text-white text-sm font-medium py-2 px-4 rounded-md transition-colors disabled:opacity-50"
+            >
+                {isDeleting ? "削除中..." : "削除"}
+            </Button>
+            {error && (
+                <p className="text-xs text-red-600 mt-1 text-center font-medium leading-tight max-w-full">
+                    {error}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/src/app/(auth)/group/_components/event-list-card.tsx
+++ b/src/app/(auth)/group/_components/event-list-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { formatToJST } from "@/lib/date";
+import DeleteEventButton from "./delete-event-button";
 
 type EventListCardProps = {
     id: string;
@@ -17,8 +18,8 @@ const EventListCard = ({
     startTime,
     endTime,
 }: EventListCardProps) => {
-    const startDate = startTime;
-    const endDate = endTime;
+    const startDate = new Date(startTime);
+    const endDate = new Date(endTime);
 
     // 日付と時刻を指定の形式にフォーマット
     const formattedDate = formatToJST(startDate, "yyyy/MM/dd");
@@ -34,11 +35,16 @@ const EventListCard = ({
                 <h3 className="text-xl font-bold text-black mb-2">{title}</h3>
                 <p className="text-base text-black">{displayDateTime}</p>
             </div>
-            <Link href={{ pathname: "/edit-event", query: { id, groupId } }}>
-                <Button className="bg-gray-100 hover:bg-gray-200 text-black text-sm font-medium py-2 px-4 border border-gray-300 rounded-md transition-colors ml-4">
-                    編集
-                </Button>
-            </Link>
+            <div className="flex flex-col gap-2 ml-4 w-24">
+                <Link
+                    href={{ pathname: "/edit-event", query: { id, groupId } }}
+                >
+                    <Button className="w-full bg-gray-100 hover:bg-gray-200 text-black text-sm font-medium py-2 px-4 border border-gray-300 rounded-md transition-colors">
+                        編集
+                    </Button>
+                </Link>
+                <DeleteEventButton id={id} groupId={groupId} />
+            </div>
         </div>
     );
 };

--- a/src/app/(auth)/group/actions.ts
+++ b/src/app/(auth)/group/actions.ts
@@ -5,6 +5,49 @@ import { createGroupService } from "@/service/group-service";
 import { firestoreGroupAdminRepository } from "@/infra/group/group-admin-repo";
 import { userGroupAdminRepo } from "@/infra/group/user-group-admin-repository";
 import { isGroupRole } from "@/domain/group";
+import { firestoreEventAdminRepository } from "@/infra/event/event-admin-repo";
+import { revalidatePath } from "next/cache";
+
+export async function authorizeGroupMember(
+    groupId: string,
+    userId: string,
+): Promise<{ authorized: true } | { authorized: false; error: string }> {
+    const memberIdsResult =
+        await userGroupAdminRepo.getUserIdsByGroupId(groupId);
+    if (memberIdsResult.isErr()) {
+        return { authorized: false, error: "グループ情報の取得に失敗しました" };
+    }
+    if (!memberIdsResult.value.includes(userId)) {
+        return {
+            authorized: false,
+            error: "このグループへのアクセス権限がありません",
+        };
+    }
+    return { authorized: true };
+}
+
+export async function deleteEventAction(
+    groupId: string,
+    eventId: string,
+): Promise<{ success: true } | { success: false; error: string }> {
+    const decodedClaims = await requireAuth();
+    const auth = await authorizeGroupMember(groupId, decodedClaims.uid);
+    if (!auth.authorized) {
+        return { success: false, error: auth.error };
+    }
+
+    const result = await firestoreEventAdminRepository.deleteNewEvent(
+        groupId,
+        eventId,
+    );
+    return result.match(
+        () => {
+            revalidatePath("/group");
+            return { success: true as const };
+        },
+        (err) => ({ success: false, error: err.message }),
+    );
+}
 
 const groupService = createGroupService({
     groupRepo: firestoreGroupAdminRepository,


### PR DESCRIPTION
## 関連する Issue

- #issue 番号

## 変更内容

- 削除ボタンのみをクライアントコンポーネント化
- 削除ロジックをgroupのaction.tsに移動

## なぜこの変更が必要か

- イベントの削除位置が分かりづらいため

## 変更の検証方法

1.

## スクリーンショット/デモ
<img width="707" height="295" alt="image" src="https://github.com/user-attachments/assets/25d20e2d-b90e-4862-932f-39e7c8a0b1d8" />

## チェックリスト

- [ ] 関連する Issue へのリンクが記述されているか
- [ ] コードがプロジェクトのコーディング規約に従っているか
- [ ] 新しいテストが追加されたか、または既存のテストがパスしているか
- [ ] ドキュメントが更新されたか (必要な場合)
- [ ] セルフレビューを行ったか

## レビュアーへの特記事項

Close #issue 番号


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Events can now be deleted directly from the event list view with a confirmation dialog and loading feedback during the deletion process

* **Changes**
  * The edit event form has been streamlined to focus exclusively on saving changes; event deletion functionality has been removed from this page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->