### PR TITLE
ユーザー表示名をgoogel account名に変更

### DIFF
--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -5,6 +5,7 @@ import { User as AuthUser } from "firebase/auth";
 export interface User {
     uid: string;
     email: string;
+    name: string;
     created_at: Date;
     updated_at: Date;
 }
@@ -19,6 +20,7 @@ export const createNewUser = (user: AuthUser): Result<User, never> => {
     return ok({
         uid: user.uid,
         email: user.email!,
+        name: user.displayName || user.email || "Unknown User",
         created_at: now,
         updated_at: now,
     });

--- a/src/infra/user/user-admin-repo.ts
+++ b/src/infra/user/user-admin-repo.ts
@@ -11,6 +11,7 @@ const toUser = (uid: string, data: FirebaseFirestore.DocumentData): User => {
     return {
         uid,
         email: data.email || "Unknown Email",
+        name: data.name || data.email || "Unknown User",
         created_at: data.created_at?.toDate() ?? new Date(),
         updated_at: data.updated_at?.toDate() ?? new Date(),
     };
@@ -26,11 +27,13 @@ export const userAdminRepo: UserRepository = {
                 if (snapshot.exists) {
                     transaction.update(docRef, {
                         email: user.email,
+                        name: user.name,
                         updated_at: FieldValue.serverTimestamp(),
                     });
                 } else {
                     transaction.set(docRef, {
                         email: user.email,
+                        name: user.name,
                         created_at: FieldValue.serverTimestamp(),
                         updated_at: FieldValue.serverTimestamp(),
                     });

--- a/src/infra/user/user-converter.ts
+++ b/src/infra/user/user-converter.ts
@@ -12,6 +12,7 @@ const userConverter: FirestoreDataConverter<User> = {
         return {
             uid: user.uid,
             email: user.email,
+            name: user.name,
             created_at: toFirestoreTimestamp(user.created_at),
             updated_at: toFirestoreTimestamp(user.updated_at),
         };
@@ -25,6 +26,7 @@ const userConverter: FirestoreDataConverter<User> = {
         return {
             uid: snapshot.id,
             email: data.email ?? snapshot.id,
+            name: data.name ?? data.email ?? snapshot.id,
             created_at: data.created_at?.toDate() ?? new Date(),
             updated_at: data.updated_at?.toDate() ?? new Date(),
         };

--- a/src/infra/user/user-repo.ts
+++ b/src/infra/user/user-repo.ts
@@ -25,11 +25,13 @@ export const userRepo: UserRepository = {
                 if (snapshot.exists()) {
                     transaction.update(doc(db, "users", user.uid), {
                         email: user.email,
+                        name: user.name,
                         updated_at: serverTimestamp(),
                     });
                 } else {
                     transaction.set(doc(db, "users", user.uid), {
                         email: user.email,
+                        name: user.name,
                         created_at: serverTimestamp(),
                         updated_at: serverTimestamp(),
                     });

--- a/src/service/group-service.ts
+++ b/src/service/group-service.ts
@@ -311,7 +311,7 @@ export const createGroupService = ({
                                                         }
                                                         return {
                                                             id,
-                                                            name: user.email,
+                                                            name: user.name,
                                                             role,
                                                         };
                                                     },


### PR DESCRIPTION
## 変更内容

- userモデルにnameフィールドを追加
- Firebase authから渡されるdisplayNameをnameに格納
- 取ってこられなかったらメールアドレスにする

## なぜこの変更が必要か

- 名前が分かりづらいため

## 変更の検証方法

1.

## スクリーンショット/デモ
<img width="375" height="652" alt="image" src="https://github.com/user-attachments/assets/dddaeed3-a251-4d5f-bc70-fc2ada46ab41" />

## チェックリスト

- [ ] 関連する Issue へのリンクが記述されているか
- [ ] コードがプロジェクトのコーディング規約に従っているか
- [ ] 新しいテストが追加されたか、または既存のテストがパスしているか
- [ ] ドキュメントが更新されたか (必要な場合)
- [ ] セルフレビューを行ったか

## レビュアーへの特記事項

Close #issue 番号


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User accounts now include display names, automatically populated from your account profile or email address.
  * Group member lists now display by name instead of email addresses for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->