### PR TITLE
feat: 希望条件をスコアリングに反映

### DIFF
--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -16,6 +16,8 @@ import { createSchedulePreferenceService } from "@/service/schedule-preference-s
 import { formatToJST } from "@/lib/date";
 import {
     EventMember,
+    findMatchingPreferredHourRange,
+    SchedulePreference,
     selectDiverseTopN,
     TimeRangeScore,
 } from "@/domain/schedule-calculator";
@@ -147,7 +149,7 @@ export async function getScheduleSuggestionsAction(
                 reason: createSuggestionReason(
                     s,
                     requiredCount,
-                    Boolean(schedulePreference),
+                    schedulePreference,
                 ),
             })),
         };
@@ -164,7 +166,7 @@ export async function getScheduleSuggestionsAction(
 const createSuggestionReason = (
     score: TimeRangeScore,
     requiredCount: number,
-    usedSchedulePreference: boolean,
+    schedulePreference: SchedulePreference | undefined,
 ): string => {
     const displayStart = formatToJST(score.timeRange.start, "M月d日 H:mm");
     const allRequiredMembersAvailable =
@@ -176,8 +178,11 @@ const createSuggestionReason = (
             : allRequiredMembersAvailable
               ? `必須メンバー全員が参加可能な${displayStart}開始の候補です。`
               : `${displayStart}開始で、必須メンバー${score.availableMemberIds.required.length}/${requiredCount}人が参加可能な候補です。`;
-    const preferenceText = usedSchedulePreference
-        ? "入力内容から抽出した曜日・時間帯の希望も加味しています。"
+    const matchingHourRange = schedulePreference
+        ? findMatchingPreferredHourRange(score.timeRange, schedulePreference)
+        : undefined;
+    const preferenceText = matchingHourRange
+        ? `入力内容から抽出した希望も加味しています。${matchingHourRange.reason}`
         : "希望時間帯の中から参加可能性をもとに選んでいます。";
 
     return `${availabilityText}${preferenceText}`;

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -166,12 +166,16 @@ const createSuggestionReason = (
     requiredCount: number,
     usedSchedulePreference: boolean,
 ): string => {
-    const allRequiredMembersAvailable =
-        score.availableMemberIds.required.length >= requiredCount;
     const displayStart = formatToJST(score.timeRange.start, "M月d日 H:mm");
-    const availabilityText = allRequiredMembersAvailable
-        ? `必須メンバー全員が参加可能な${displayStart}開始の候補です。`
-        : `${displayStart}開始で、必須メンバー${score.availableMemberIds.required.length}/${requiredCount}人が参加可能な候補です。`;
+    const allRequiredMembersAvailable =
+        requiredCount > 0 &&
+        score.availableMemberIds.required.length >= requiredCount;
+    const availabilityText =
+        requiredCount === 0
+            ? `${displayStart}開始で、参加可能性をもとに選んだ候補です。`
+            : allRequiredMembersAvailable
+              ? `必須メンバー全員が参加可能な${displayStart}開始の候補です。`
+              : `${displayStart}開始で、必須メンバー${score.availableMemberIds.required.length}/${requiredCount}人が参加可能な候補です。`;
     const preferenceText = usedSchedulePreference
         ? "入力内容から抽出した曜日・時間帯の希望も加味しています。"
         : "希望時間帯の中から参加可能性をもとに選んでいます。";

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -12,8 +12,13 @@ import { googleCalendarRepository } from "@/infra/calendar/google-calendar-repo"
 import { googleTokenRepository } from "@/infra/token/google-token-repo";
 import { geminiRepo } from "@/infra/ai/gemini-repo";
 import { createCalculateFreeTimeService } from "@/service/calculate-free-time-service";
-import { createScheduleSuggestionService } from "@/service/schedule-suggestion-service";
-import type { EventMember } from "@/domain/schedule-calculator";
+import { createSchedulePreferenceService } from "@/service/schedule-preference-service";
+import { formatToJST } from "@/lib/date";
+import {
+    EventMember,
+    selectDiverseTopN,
+    TimeRangeScore,
+} from "@/domain/schedule-calculator";
 
 export async function getScheduleSuggestionsAction(
     groupId: string,
@@ -97,6 +102,20 @@ export async function getScheduleSuggestionsAction(
                 ? validCandidates.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].hours)
                 : undefined;
 
+        const preferenceResult = await createSchedulePreferenceService(
+            geminiRepo,
+        ).extractPreference(draft.description, validCandidates);
+
+        const schedulePreference = preferenceResult.isOk()
+            ? preferenceResult.value
+            : undefined;
+        if (preferenceResult.isErr()) {
+            console.warn(
+                "Failed to extract schedule preference:",
+                preferenceResult.error.message,
+            );
+        }
+
         const scoresResult = await createCalculateFreeTimeService(
             googleCalendarRepository,
             googleTokenRepository,
@@ -105,6 +124,7 @@ export async function getScheduleSuggestionsAction(
             durationMinutes,
             members,
             allowedHourRanges,
+            schedulePreference,
         );
 
         if (scoresResult.isErr()) {
@@ -117,38 +137,18 @@ export async function getScheduleSuggestionsAction(
         }
 
         const requiredCount = members.filter((m) => m.isRequired).length;
-
-        // AIプロンプト用の時間帯ラベルも検証済みの validCandidates から導出
-        const timeConstraint =
-            validCandidates.length > 0
-                ? `\n希望時間帯: ${validCandidates.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].label).join("、")}`
-                : "";
-        const descriptionWithTimeConstraint =
-            draft.description + timeConstraint;
-
-        const suggestionsResult = await createScheduleSuggestionService(
-            geminiRepo,
-        ).suggestSchedule(
-            descriptionWithTimeConstraint,
-            scoresResult.value,
-            requiredCount,
-        );
-
-        if (suggestionsResult.isErr()) {
-            return {
-                success: false,
-                error:
-                    "AI提案の生成に失敗しました: " +
-                    suggestionsResult.error.message,
-            };
-        }
+        const suggestions = selectDiverseTopN(scoresResult.value, 3);
 
         return {
             success: true,
-            suggestions: suggestionsResult.value.map((s) => ({
+            suggestions: suggestions.map((s) => ({
                 start: s.timeRange.start.toISOString(),
                 end: s.timeRange.end.toISOString(),
-                reason: s.reason,
+                reason: createSuggestionReason(
+                    s,
+                    requiredCount,
+                    Boolean(schedulePreference),
+                ),
             })),
         };
     } catch (error) {
@@ -160,6 +160,24 @@ export async function getScheduleSuggestionsAction(
         };
     }
 }
+
+const createSuggestionReason = (
+    score: TimeRangeScore,
+    requiredCount: number,
+    usedSchedulePreference: boolean,
+): string => {
+    const allRequiredMembersAvailable =
+        score.availableMemberIds.required.length >= requiredCount;
+    const displayStart = formatToJST(score.timeRange.start, "M月d日 H:mm");
+    const availabilityText = allRequiredMembersAvailable
+        ? `必須メンバー全員が参加可能な${displayStart}開始の候補です。`
+        : `${displayStart}開始で、必須メンバー${score.availableMemberIds.required.length}/${requiredCount}人が参加可能な候補です。`;
+    const preferenceText = usedSchedulePreference
+        ? "入力内容から抽出した曜日・時間帯の希望も加味しています。"
+        : "希望時間帯の中から参加可能性をもとに選んでいます。";
+
+    return `${availabilityText}${preferenceText}`;
+};
 
 export async function createEventAction(
     groupId: string,

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -2,8 +2,10 @@ vi.mock("server-only", () => ({}));
 import {
     createSlots,
     calculateTimeRangeScores,
+    calculateSchedulePreferenceScore,
     EventMember,
     SchedulePreferenceSchema,
+    selectDiverseTopN,
 } from "../schedule-calculator";
 import { UserTimeRanges } from "@/domain/calendar";
 
@@ -274,5 +276,234 @@ describe("calculateTimeRangeScores", () => {
         );
         expect(result).toHaveLength(1);
         expect(result[0].score).toBe(11); // 10 + 1
+    });
+
+    it("should add small schedule preference scores without exceeding required member score", () => {
+        const timeRange = {
+            start: new Date("2026-02-27T09:00:00.000Z"), // JST Friday 18:00
+            end: new Date("2026-02-27T10:00:00.000Z"),
+        };
+        const members: EventMember[] = [
+            {
+                uid: "user1",
+                isRequired: true,
+            } as EventMember,
+        ];
+        const memberAvailability: UserTimeRanges[] = [
+            {
+                userId: "user1",
+                timeRanges: [timeRange],
+            },
+        ];
+
+        const result = calculateTimeRangeScores(
+            timeRange,
+            60,
+            memberAvailability,
+            members,
+            30,
+            undefined,
+            {
+                dayWeights: [
+                    {
+                        dayOfWeek: "friday",
+                        reason: "金曜日が適しています。",
+                    },
+                ],
+                hourRangeWeights: [
+                    {
+                        startHour: 18,
+                        durationHours: 3,
+                        reason: "夕方が適しています。",
+                    },
+                ],
+                summary: "金曜日の夕方を優先します。",
+            },
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].score).toBe(13);
+    });
+
+    it("should keep required member availability above preference-only matches", () => {
+        const timeRange = {
+            start: new Date("2026-02-27T09:00:00.000Z"), // JST Friday 18:00
+            end: new Date("2026-02-27T11:00:00.000Z"),
+        };
+        const members: EventMember[] = [
+            {
+                uid: "user1",
+                isRequired: true,
+            } as EventMember,
+        ];
+        const memberAvailability: UserTimeRanges[] = [
+            {
+                userId: "user1",
+                timeRanges: [
+                    {
+                        start: new Date("2026-02-27T10:00:00.000Z"),
+                        end: new Date("2026-02-27T11:00:00.000Z"),
+                    },
+                ],
+            },
+        ];
+
+        const result = calculateTimeRangeScores(
+            timeRange,
+            60,
+            memberAvailability,
+            members,
+            60,
+            undefined,
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 18,
+                        durationHours: 1,
+                        reason: "18時台が適しています。",
+                    },
+                ],
+                summary: "金曜日の18時台を優先します。",
+            },
+        );
+
+        expect(result).toHaveLength(2);
+        expect(result[0].score).toBe(2);
+        expect(result[1].score).toBe(10);
+    });
+});
+
+describe("calculateSchedulePreferenceScore", () => {
+    it("should match hour ranges that cross midnight", () => {
+        const score = calculateSchedulePreferenceScore(
+            {
+                start: new Date("2026-02-27T16:00:00.000Z"), // JST Saturday 01:00
+                end: new Date("2026-02-27T17:00:00.000Z"),
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 22,
+                        durationHours: 4,
+                        reason: "夜から深夜が適しています。",
+                    },
+                ],
+                summary: "夜から深夜を優先します。",
+            },
+        );
+
+        expect(score).toBe(2);
+    });
+
+    it("should not add score when preference arrays are empty", () => {
+        const score = calculateSchedulePreferenceScore(
+            {
+                start: new Date("2026-02-27T09:00:00.000Z"),
+                end: new Date("2026-02-27T10:00:00.000Z"),
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [],
+                summary: "希望条件なし。",
+            },
+        );
+
+        expect(score).toBe(0);
+    });
+});
+
+describe("selectDiverseTopN", () => {
+    it("should select high-score candidates without overlapping selected slots", () => {
+        const scores = [
+            {
+                timeRange: {
+                    start: new Date("2026-02-27T09:00:00.000Z"),
+                    end: new Date("2026-02-27T11:00:00.000Z"),
+                },
+                availableMemberIds: { required: ["user1"], optional: [] },
+                score: 13,
+            },
+            {
+                timeRange: {
+                    start: new Date("2026-02-27T09:30:00.000Z"),
+                    end: new Date("2026-02-27T11:30:00.000Z"),
+                },
+                availableMemberIds: { required: ["user1"], optional: [] },
+                score: 12,
+            },
+            {
+                timeRange: {
+                    start: new Date("2026-02-27T12:00:00.000Z"),
+                    end: new Date("2026-02-27T14:00:00.000Z"),
+                },
+                availableMemberIds: { required: ["user1"], optional: [] },
+                score: 11,
+            },
+        ];
+
+        const result = selectDiverseTopN(scores, 2);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T09:00:00.000Z",
+        );
+        expect(result[1].timeRange.start.toISOString()).toBe(
+            "2026-02-27T12:00:00.000Z",
+        );
+    });
+
+    it("should return an empty array when n is not positive", () => {
+        const result = selectDiverseTopN(
+            [
+                {
+                    timeRange: {
+                        start: new Date("2026-02-27T09:00:00.000Z"),
+                        end: new Date("2026-02-27T10:00:00.000Z"),
+                    },
+                    availableMemberIds: { required: [], optional: [] },
+                    score: 1,
+                },
+            ],
+            0,
+        );
+
+        expect(result).toEqual([]);
+    });
+
+    it("should return only one candidate when all candidates overlap", () => {
+        const result = selectDiverseTopN(
+            [
+                {
+                    timeRange: {
+                        start: new Date("2026-02-27T09:00:00.000Z"),
+                        end: new Date("2026-02-27T11:00:00.000Z"),
+                    },
+                    availableMemberIds: { required: ["user1"], optional: [] },
+                    score: 13,
+                },
+                {
+                    timeRange: {
+                        start: new Date("2026-02-27T09:30:00.000Z"),
+                        end: new Date("2026-02-27T11:30:00.000Z"),
+                    },
+                    availableMemberIds: { required: ["user1"], optional: [] },
+                    score: 12,
+                },
+                {
+                    timeRange: {
+                        start: new Date("2026-02-27T10:00:00.000Z"),
+                        end: new Date("2026-02-27T12:00:00.000Z"),
+                    },
+                    availableMemberIds: { required: ["user1"], optional: [] },
+                    score: 11,
+                },
+            ],
+            3,
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].score).toBe(13);
     });
 });

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -4,6 +4,7 @@ import {
     calculateTimeRangeScores,
     calculateSchedulePreferenceScore,
     EventMember,
+    findMatchingPreferredHourRange,
     SchedulePreferenceSchema,
     selectDiverseTopN,
 } from "../schedule-calculator";
@@ -375,6 +376,50 @@ describe("calculateTimeRangeScores", () => {
 });
 
 describe("calculateSchedulePreferenceScore", () => {
+    it("should match when the whole slot is inside the preferred hour range", () => {
+        const score = calculateSchedulePreferenceScore(
+            {
+                start: new Date("2026-02-27T10:00:00.000Z"), // JST Friday 19:00
+                end: new Date("2026-02-27T12:00:00.000Z"), // JST Friday 21:00
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 19,
+                        durationHours: 3,
+                        reason: "19時から22時が適しています。",
+                    },
+                ],
+                summary: "19時から22時を優先します。",
+            },
+        );
+
+        expect(score).toBe(2);
+    });
+
+    it("should not match when the slot starts inside but ends outside the preferred hour range", () => {
+        const score = calculateSchedulePreferenceScore(
+            {
+                start: new Date("2026-02-27T12:00:00.000Z"), // JST Friday 21:00
+                end: new Date("2026-02-27T14:00:00.000Z"), // JST Friday 23:00
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 19,
+                        durationHours: 3,
+                        reason: "19時から22時が適しています。",
+                    },
+                ],
+                summary: "19時から22時を優先します。",
+            },
+        );
+
+        expect(score).toBe(0);
+    });
+
     it("should match hour ranges that cross midnight", () => {
         const score = calculateSchedulePreferenceScore(
             {
@@ -411,6 +456,52 @@ describe("calculateSchedulePreferenceScore", () => {
         );
 
         expect(score).toBe(0);
+    });
+});
+
+describe("findMatchingPreferredHourRange", () => {
+    it("should return the matching hour range with its reason", () => {
+        const result = findMatchingPreferredHourRange(
+            {
+                start: new Date("2026-02-27T10:00:00.000Z"), // JST Friday 19:00
+                end: new Date("2026-02-27T12:00:00.000Z"), // JST Friday 21:00
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 19,
+                        durationHours: 3,
+                        reason: "飲み会なので19時から22時が適しています。",
+                    },
+                ],
+                summary: "19時から22時を優先します。",
+            },
+        );
+
+        expect(result?.reason).toBe("飲み会なので19時から22時が適しています。");
+    });
+
+    it("should return undefined when no hour range contains the whole slot", () => {
+        const result = findMatchingPreferredHourRange(
+            {
+                start: new Date("2026-02-27T12:00:00.000Z"), // JST Friday 21:00
+                end: new Date("2026-02-27T14:00:00.000Z"), // JST Friday 23:00
+            },
+            {
+                dayWeights: [],
+                hourRangeWeights: [
+                    {
+                        startHour: 19,
+                        durationHours: 3,
+                        reason: "19時から22時が適しています。",
+                    },
+                ],
+                summary: "19時から22時を優先します。",
+            },
+        );
+
+        expect(result).toBeUndefined();
     });
 });
 

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -12,6 +12,8 @@ export interface EventMember extends User {
 
 export const MEMBER_REQUIRED_SCORE = 10;
 export const MEMBER_OPTIONAL_SCORE = 1;
+export const SCHEDULE_PREFERENCE_DAY_SCORE = 1;
+export const SCHEDULE_PREFERENCE_HOUR_RANGE_SCORE = 2;
 
 export const SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES = [
     "sunday",
@@ -188,6 +190,7 @@ export const calculateTimeRangeScores = (
     members: EventMember[],
     slotIntervalMinutes: number = 30,
     allowedHourRanges?: { start: number; end: number }[],
+    schedulePreference?: SchedulePreference,
 ): TimeRangeScore[] => {
     const slots: TimeRangeScore[] = createSlots(
         timeRange,
@@ -233,5 +236,84 @@ export const calculateTimeRangeScores = (
         }
     }
 
+    if (schedulePreference) {
+        for (const slot of slots) {
+            slot.score += calculateSchedulePreferenceScore(
+                slot.timeRange,
+                schedulePreference,
+            );
+        }
+    }
+
     return slots;
+};
+
+export const calculateSchedulePreferenceScore = (
+    timeRange: TimeRange,
+    schedulePreference: SchedulePreference,
+): number => {
+    const start = timeRange.start;
+    const dayScore = matchesPreferredDay(start, schedulePreference)
+        ? SCHEDULE_PREFERENCE_DAY_SCORE
+        : 0;
+    const hourRangeScore = matchesPreferredHourRange(start, schedulePreference)
+        ? SCHEDULE_PREFERENCE_HOUR_RANGE_SCORE
+        : 0;
+
+    return dayScore + hourRangeScore;
+};
+
+export const selectDiverseTopN = (
+    scores: TimeRangeScore[],
+    n: number,
+): TimeRangeScore[] => {
+    if (n <= 0) return [];
+
+    const selected: TimeRangeScore[] = [];
+
+    for (const candidate of scores.toSorted((a, b) => b.score - a.score)) {
+        if (selected.length >= n) break;
+
+        const overlapsWithSelected = selected.some((selectedScore) =>
+            timeRangesOverlap(candidate.timeRange, selectedScore.timeRange),
+        );
+        if (!overlapsWithSelected) {
+            selected.push(candidate);
+        }
+    }
+
+    return selected;
+};
+
+const matchesPreferredDay = (
+    start: Date,
+    schedulePreference: SchedulePreference,
+): boolean => {
+    const dayOfWeek = SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES[getJSTDay(start)];
+
+    return schedulePreference.dayWeights.some(
+        (day) => day.dayOfWeek === dayOfWeek,
+    );
+};
+
+const matchesPreferredHourRange = (
+    start: Date,
+    schedulePreference: SchedulePreference,
+): boolean => {
+    const hour = getJSTHour(start);
+
+    return schedulePreference.hourRangeWeights.some((range) => {
+        const elapsedHours = (hour - range.startHour + 24) % 24;
+        return elapsedHours < range.durationHours;
+    });
+};
+
+const timeRangesOverlap = (a: TimeRange, b: TimeRange): boolean =>
+    a.start < b.end && a.end > b.start;
+
+const getJSTHour = (date: Date): number => (date.getUTCHours() + 9) % 24;
+
+const getJSTDay = (date: Date): number => {
+    const jstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+    return jstDate.getUTCDay();
 };

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -271,7 +271,7 @@ export const selectDiverseTopN = (
 
     const selected: TimeRangeScore[] = [];
 
-    for (const candidate of scores.toSorted((a, b) => b.score - a.score)) {
+    for (const candidate of [...scores].sort((a, b) => b.score - a.score)) {
         if (selected.length >= n) break;
 
         const overlapsWithSelected = selected.some((selectedScore) =>

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -256,12 +256,23 @@ export const calculateSchedulePreferenceScore = (
     const dayScore = matchesPreferredDay(start, schedulePreference)
         ? SCHEDULE_PREFERENCE_DAY_SCORE
         : 0;
-    const hourRangeScore = matchesPreferredHourRange(start, schedulePreference)
+    const hourRangeScore = findMatchingPreferredHourRange(
+        timeRange,
+        schedulePreference,
+    )
         ? SCHEDULE_PREFERENCE_HOUR_RANGE_SCORE
         : 0;
 
     return dayScore + hourRangeScore;
 };
+
+export const findMatchingPreferredHourRange = (
+    timeRange: TimeRange,
+    schedulePreference: SchedulePreference,
+): SchedulePreferenceHourRange | undefined =>
+    schedulePreference.hourRangeWeights.find((range) =>
+        containsWholeTimeRange(timeRange, range),
+    );
 
 export const selectDiverseTopN = (
     scores: TimeRangeScore[],
@@ -296,22 +307,37 @@ const matchesPreferredDay = (
     );
 };
 
-const matchesPreferredHourRange = (
-    start: Date,
-    schedulePreference: SchedulePreference,
+const containsWholeTimeRange = (
+    timeRange: TimeRange,
+    range: SchedulePreferenceHourRange,
 ): boolean => {
-    const hour = getJSTHour(start);
+    const slotDurationMinutes =
+        (timeRange.end.getTime() - timeRange.start.getTime()) / (60 * 1000);
+    const durationMinutes = range.durationHours * 60;
+    if (slotDurationMinutes <= 0 || slotDurationMinutes > durationMinutes) {
+        return false;
+    }
 
-    return schedulePreference.hourRangeWeights.some((range) => {
-        const elapsedHours = (hour - range.startHour + 24) % 24;
-        return elapsedHours < range.durationHours;
-    });
+    const startOffsetMinutes = getMinutesSinceJSTHour(
+        timeRange.start,
+        range.startHour,
+    );
+
+    return startOffsetMinutes + slotDurationMinutes <= durationMinutes;
 };
 
 const timeRangesOverlap = (a: TimeRange, b: TimeRange): boolean =>
     a.start < b.end && a.end > b.start;
 
 const getJSTHour = (date: Date): number => (date.getUTCHours() + 9) % 24;
+
+const getJSTMinuteOfDay = (date: Date): number =>
+    getJSTHour(date) * 60 + date.getUTCMinutes();
+
+const getMinutesSinceJSTHour = (date: Date, startHour: number): number => {
+    const startMinuteOfDay = startHour * 60;
+    return (getJSTMinuteOfDay(date) - startMinuteOfDay + 24 * 60) % (24 * 60);
+};
 
 const getJSTDay = (date: Date): number => {
     const jstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);

--- a/src/service/calculate-free-time-service.ts
+++ b/src/service/calculate-free-time-service.ts
@@ -11,6 +11,7 @@ import { createCalendarService } from "./calendar-service";
 import {
     calculateTimeRangeScores,
     EventMember,
+    SchedulePreference,
     TimeRangeScore,
 } from "@/domain/schedule-calculator";
 
@@ -27,6 +28,7 @@ export interface CalculateFreeTimeService {
         eventDurationMinutes: number,
         members: EventMember[],
         allowedHourRanges?: { start: number; end: number }[],
+        schedulePreference?: SchedulePreference,
     ): ResultAsync<TimeRangeScore[], CalendarError>;
 }
 
@@ -45,6 +47,7 @@ export const createCalculateFreeTimeService = (
             eventDurationMinutes,
             members,
             allowedHourRanges,
+            schedulePreference,
         ) =>
             ResultAsync.combine(
                 members.map((user) =>
@@ -71,6 +74,7 @@ export const createCalculateFreeTimeService = (
                     //   → 当面は30分固定を維持し、別Issueで検討する
                     undefined,
                     allowedHourRanges,
+                    schedulePreference,
                 ),
             ),
     };

--- a/src/service/schedule-suggestion-service.ts
+++ b/src/service/schedule-suggestion-service.ts
@@ -27,8 +27,8 @@ export function generatePrompt(
     description: string,
     requiredMemberCount: number,
 ): string {
-    const candidatesText = candidates
-        .toSorted((a, b) => b.score - a.score)
+    const candidatesText = [...candidates]
+        .sort((a, b) => b.score - a.score)
         .slice(0, 30) // スコア上位30件
         .map((c, idx) => {
             const start = c.timeRange.start;


### PR DESCRIPTION
## 概要

Gemini が抽出した `SchedulePreference` をスコアリングに反映し、最終候補選定を Gemini ではなくアプリ側のスコア順で行うようにしました。

PR3では UI で選択された朝/昼/夕/夜の時間帯フィルタは維持し、その範囲内で Gemini preference を小さく加点します。UI指定時間帯外の譲歩候補は、後続PRで希望候補・譲歩候補の二系統表示として扱う想定です。

## 変更内容

- `calculateTimeRangeScores` に `SchedulePreference` を渡せるようにした
- 曜日一致 `+1`、時間帯一致 `+2` の小さな加点を追加した
- `startHour + durationHours` 形式の日跨ぎ時間帯判定に対応した
- スコア上位候補から重複する時間帯を除外する `selectDiverseTopN` を追加した
- 作成画面の候補選定を Gemini 最終選定からアプリ側選定に変更した
- preference取得失敗時は、既存に近い挙動としてUI指定時間帯内で候補を作る
- 候補理由にJST開始日時と必須参加者数を含め、候補ごとに少し差が出るようにした

## 方針

- 必須メンバー1人分のスコアは `+10`
- preference由来の加点は最大 `+3`
- そのため、Gemini preference が必須メンバーの参加可能性を大きく覆さないようにしています
- UI指定時間帯外の候補提示は、このPRでは行いません

## 確認したこと

- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event scheduling now derives schedule preferences from event descriptions and uses them to boost matching time slots.
  * Suggestions are generated deterministically from scoring and presented as diverse, non-overlapping options, with clearer rationale tied to availability at the candidate times.
* **Tests**
  * Expanded coverage for preference-based scoring (including empty preferences and midnight-crossing ranges) and for selecting top diverse suggestions without overlaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->