### PR TITLE
fix: pnpm の Build Scripts を許可

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@firebase/util': true
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  unrs-resolver: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
-  '@firebase/util': true
-  esbuild: true
-  protobufjs: true
-  sharp: true
-  unrs-resolver: true
+    "@firebase/util": true
+    esbuild: true
+    protobufjs: true
+    sharp: true
+    unrs-resolver: true


### PR DESCRIPTION
## 関連する Issue

- #270 

## 変更内容

- `pnpm approve-builds` でビルドスクリプトの実行を許容

## なぜこの変更が必要か

- Firebase App Hosting でビルドが失敗していたため

## 変更の検証方法

1. Firebase App Hosting でビルドしてみないとわからない…

## チェックリスト

- [x] 関連する Issue へのリンクが記述されているか
- [x] コードがプロジェクトのコーディング規約に従っているか
- [x] 新しいテストが追加されたか、または既存のテストがパスしているか
- [x] ドキュメントが更新されたか (必要な場合)
- [x] セルフレビューを行ったか

## レビュアーへの特記事項

Close #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration to allow build/script execution for a defined set of tooling and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->