### PR TITLE
期間を固定からフォーム入力で指定できるように変更

### DIFF
--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -6,12 +6,13 @@ import type { EventTimeOfDay, EventDraft } from "@/domain/event";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { useForm, SubmitHandler } from "react-hook-form";
+import { useForm, SubmitHandler, useWatch } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import Fuse from "fuse.js";
 import { getScheduleSuggestionsAction } from "./actions";
 import {
     getDefaultSuggestionSearchDateValues,
+    getInclusiveDateInputDayCount,
     MAX_SUGGESTION_SEARCH_DAYS,
 } from "@/domain/suggestion-search-range";
 
@@ -32,13 +33,16 @@ type Props = { groupId: string; users: User[] };
 
 export default function CreateEventForm({ groupId, users }: Props) {
     const router = useRouter();
-    const defaultSuggestionSearchDateValues =
-        getDefaultSuggestionSearchDateValues();
+    const defaultSuggestionSearchDateValues = useMemo(
+        () => getDefaultSuggestionSearchDateValues(),
+        [],
+    );
     const {
         register,
         handleSubmit,
         formState: { errors, isSubmitting },
         setValue,
+        control,
     } = useForm<EventDraft>({
         defaultValues: {
             title: "",
@@ -53,6 +57,10 @@ export default function CreateEventForm({ groupId, users }: Props) {
     const [query, setQuery] = useState("");
     const [selected, setSelected] = useState<User[]>([]);
     const [error, setError] = useState<string | null>(null);
+    const watchedSearchStartDate = useWatch({
+        control,
+        name: "searchStartDate",
+    });
 
     const fuse = useMemo(
         () => new Fuse(users, { keys: ["username", "email"], threshold: 0.3 }),
@@ -159,6 +167,18 @@ export default function CreateEventForm({ groupId, users }: Props) {
                             }
                             {...register("searchStartDate", {
                                 required: "検索開始日は必須です",
+                                validate: (value) => {
+                                    if (!value) {
+                                        return "検索開始日は必須です";
+                                    }
+                                    if (
+                                        value <
+                                        defaultSuggestionSearchDateValues.searchStartDate
+                                    ) {
+                                        return "検索開始日は明日以降の日付を指定してください";
+                                    }
+                                    return true;
+                                },
                             })}
                             className="event-form-input mt-1"
                         />
@@ -179,6 +199,7 @@ export default function CreateEventForm({ groupId, users }: Props) {
                             type="date"
                             id="searchEndDate"
                             min={
+                                watchedSearchStartDate ||
                                 defaultSuggestionSearchDateValues.searchStartDate
                             }
                             {...register("searchEndDate", {
@@ -192,6 +213,19 @@ export default function CreateEventForm({ groupId, users }: Props) {
                                         value < formValues.searchStartDate
                                     ) {
                                         return "検索終了日は検索開始日以降の日付を指定してください";
+                                    }
+                                    if (formValues.searchStartDate) {
+                                        const selectedDays =
+                                            getInclusiveDateInputDayCount(
+                                                formValues.searchStartDate,
+                                                value,
+                                            );
+                                        if (
+                                            selectedDays >
+                                            MAX_SUGGESTION_SEARCH_DAYS
+                                        ) {
+                                            return `検索期間は最大${MAX_SUGGESTION_SEARCH_DAYS}日まで指定できます`;
+                                        }
                                     }
                                     return true;
                                 },

--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -10,6 +10,10 @@ import { useForm, SubmitHandler } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import Fuse from "fuse.js";
 import { getScheduleSuggestionsAction } from "./actions";
+import {
+    getDefaultSuggestionSearchDateValues,
+    MAX_SUGGESTION_SEARCH_DAYS,
+} from "@/domain/suggestion-search-range";
 
 type User = { id: string; username: string; email: string };
 
@@ -28,6 +32,8 @@ type Props = { groupId: string; users: User[] };
 
 export default function CreateEventForm({ groupId, users }: Props) {
     const router = useRouter();
+    const defaultSuggestionSearchDateValues =
+        getDefaultSuggestionSearchDateValues();
     const {
         register,
         handleSubmit,
@@ -38,6 +44,8 @@ export default function CreateEventForm({ groupId, users }: Props) {
             title: "",
             duration: "",
             timeOfDayCandidate: [],
+            searchStartDate: defaultSuggestionSearchDateValues.searchStartDate,
+            searchEndDate: defaultSuggestionSearchDateValues.searchEndDate,
             priorityParticipants: "",
             description: "",
         },
@@ -132,6 +140,75 @@ export default function CreateEventForm({ groupId, users }: Props) {
                         {errors.duration.message}
                     </p>
                 )}
+            </div>
+            <div>
+                <Label className="event-form-label">候補検索期間</Label>
+                <div className="mt-2 grid gap-4 md:grid-cols-2">
+                    <div>
+                        <Label
+                            htmlFor="searchStartDate"
+                            className="text-sm text-black"
+                        >
+                            開始日
+                        </Label>
+                        <Input
+                            type="date"
+                            id="searchStartDate"
+                            min={
+                                defaultSuggestionSearchDateValues.searchStartDate
+                            }
+                            {...register("searchStartDate", {
+                                required: "検索開始日は必須です",
+                            })}
+                            className="event-form-input mt-1"
+                        />
+                        {errors.searchStartDate && (
+                            <p className="event-form-error">
+                                {errors.searchStartDate.message}
+                            </p>
+                        )}
+                    </div>
+                    <div>
+                        <Label
+                            htmlFor="searchEndDate"
+                            className="text-sm text-black"
+                        >
+                            終了日
+                        </Label>
+                        <Input
+                            type="date"
+                            id="searchEndDate"
+                            min={
+                                defaultSuggestionSearchDateValues.searchStartDate
+                            }
+                            {...register("searchEndDate", {
+                                required: "検索終了日は必須です",
+                                validate: (value, formValues) => {
+                                    if (!value) {
+                                        return "検索終了日は必須です";
+                                    }
+                                    if (
+                                        formValues.searchStartDate &&
+                                        value < formValues.searchStartDate
+                                    ) {
+                                        return "検索終了日は検索開始日以降の日付を指定してください";
+                                    }
+                                    return true;
+                                },
+                            })}
+                            className="event-form-input mt-1"
+                        />
+                        {errors.searchEndDate && (
+                            <p className="event-form-error">
+                                {errors.searchEndDate.message}
+                            </p>
+                        )}
+                    </div>
+                </div>
+                <p className="text-sm text-gray-500 mt-1">
+                    最大{MAX_SUGGESTION_SEARCH_DAYS}
+                    日間までの範囲で候補を探します。
+                </p>
             </div>
             <div>
                 <Label className="event-form-label">時間帯</Label>

--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -11,8 +11,10 @@ import { Input } from "@/components/ui/input";
 import Fuse from "fuse.js";
 import { getScheduleSuggestionsAction } from "./actions";
 import {
+    calculateMaxSearchEndDate,
     getDefaultSuggestionSearchDateValues,
     getInclusiveDateInputDayCount,
+    MAX_DATE_INPUT_VALUE,
     MAX_SUGGESTION_SEARCH_DAYS,
 } from "@/domain/suggestion-search-range";
 
@@ -61,6 +63,10 @@ export default function CreateEventForm({ groupId, users }: Props) {
         control,
         name: "searchStartDate",
     });
+    const searchEndDateMax = calculateMaxSearchEndDate(
+        watchedSearchStartDate ||
+            defaultSuggestionSearchDateValues.searchStartDate,
+    );
 
     const fuse = useMemo(
         () => new Fuse(users, { keys: ["username", "email"], threshold: 0.3 }),
@@ -165,6 +171,7 @@ export default function CreateEventForm({ groupId, users }: Props) {
                             min={
                                 defaultSuggestionSearchDateValues.searchStartDate
                             }
+                            max={MAX_DATE_INPUT_VALUE}
                             {...register("searchStartDate", {
                                 required: "検索開始日は必須です",
                                 validate: (value) => {
@@ -202,6 +209,7 @@ export default function CreateEventForm({ groupId, users }: Props) {
                                 watchedSearchStartDate ||
                                 defaultSuggestionSearchDateValues.searchStartDate
                             }
+                            max={searchEndDateMax}
                             {...register("searchEndDate", {
                                 required: "検索終了日は必須です",
                                 validate: (value, formValues) => {

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -14,6 +14,7 @@ import { geminiRepo } from "@/infra/ai/gemini-repo";
 import { createCalculateFreeTimeService } from "@/service/calculate-free-time-service";
 import { createSchedulePreferenceService } from "@/service/schedule-preference-service";
 import { formatToJST } from "@/lib/date";
+import { buildSuggestionSearchRange } from "@/domain/suggestion-search-range";
 import {
     EventMember,
     findMatchingPreferredHourRange,
@@ -81,16 +82,14 @@ export async function getScheduleSuggestionsAction(
 
         const durationMinutes = parseDuration(draft.duration);
 
-        const now = new Date();
-        const tomorrow = new Date(now);
-        tomorrow.setDate(tomorrow.getDate() + 1);
-        tomorrow.setHours(0, 0, 0, 0);
-
-        const rangeEnd = new Date(now);
-        rangeEnd.setDate(rangeEnd.getDate() + 14);
-        rangeEnd.setHours(23, 59, 59, 999);
-
-        const scheduleRange = { start: tomorrow, end: rangeEnd };
+        const scheduleRangeResult = buildSuggestionSearchRange(draft);
+        if (!scheduleRangeResult.success) {
+            return {
+                success: false,
+                error: scheduleRangeResult.error,
+            };
+        }
+        const scheduleRange = scheduleRangeResult.range;
 
         // UI の timeOfDayCandidate（morning/noon/evening/night）を
         // JST の時刻範囲に変換し、スロット生成時のフィルタとして渡す。

--- a/src/domain/__tests__/suggestion-search-range.test.ts
+++ b/src/domain/__tests__/suggestion-search-range.test.ts
@@ -1,6 +1,7 @@
 import {
     buildSuggestionSearchRange,
     getDefaultSuggestionSearchDateValues,
+    getInclusiveDateInputDayCount,
     MAX_SUGGESTION_SEARCH_DAYS,
 } from "../suggestion-search-range";
 
@@ -17,6 +18,20 @@ describe("getDefaultSuggestionSearchDateValues", () => {
     });
 });
 
+describe("getInclusiveDateInputDayCount", () => {
+    it("should count the start and end date inclusively", () => {
+        expect(getInclusiveDateInputDayCount("2026-07-10", "2026-07-12")).toBe(
+            3,
+        );
+    });
+
+    it("should return 1 when start and end are the same date", () => {
+        expect(getInclusiveDateInputDayCount("2026-07-10", "2026-07-10")).toBe(
+            1,
+        );
+    });
+});
+
 describe("buildSuggestionSearchRange", () => {
     const now = new Date("2026-06-18T10:00:00.000Z");
 
@@ -28,7 +43,7 @@ describe("buildSuggestionSearchRange", () => {
         expect(result.range.start.toISOString()).toBe(
             "2026-06-18T15:00:00.000Z",
         );
-        expect(result.range.end.toISOString()).toBe("2026-07-02T14:59:59.999Z");
+        expect(result.range.end.toISOString()).toBe("2026-07-02T15:00:00.000Z");
     });
 
     it("should build a custom JST date range", () => {
@@ -45,7 +60,7 @@ describe("buildSuggestionSearchRange", () => {
         expect(result.range.start.toISOString()).toBe(
             "2026-07-09T15:00:00.000Z",
         );
-        expect(result.range.end.toISOString()).toBe("2026-07-12T14:59:59.999Z");
+        expect(result.range.end.toISOString()).toBe("2026-07-12T15:00:00.000Z");
     });
 
     it("should reject malformed date strings", () => {

--- a/src/domain/__tests__/suggestion-search-range.test.ts
+++ b/src/domain/__tests__/suggestion-search-range.test.ts
@@ -99,6 +99,18 @@ describe("buildSuggestionSearchRange", () => {
         expect(result.success).toBe(false);
     });
 
+    it("should reject when end date is exactly one day before start date", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026-07-12",
+                searchEndDate: "2026-07-11",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(false);
+    });
+
     it("should reject ranges longer than the maximum search days", () => {
         const result = buildSuggestionSearchRange(
             {

--- a/src/domain/__tests__/suggestion-search-range.test.ts
+++ b/src/domain/__tests__/suggestion-search-range.test.ts
@@ -1,0 +1,100 @@
+import {
+    buildSuggestionSearchRange,
+    getDefaultSuggestionSearchDateValues,
+    MAX_SUGGESTION_SEARCH_DAYS,
+} from "../suggestion-search-range";
+
+describe("getDefaultSuggestionSearchDateValues", () => {
+    it("should default to tomorrow through 14 days from tomorrow in JST date strings", () => {
+        const result = getDefaultSuggestionSearchDateValues(
+            new Date("2026-06-18T10:00:00.000Z"),
+        );
+
+        expect(result).toEqual({
+            searchStartDate: "2026-06-19",
+            searchEndDate: "2026-07-02",
+        });
+    });
+});
+
+describe("buildSuggestionSearchRange", () => {
+    const now = new Date("2026-06-18T10:00:00.000Z");
+
+    it("should build the default JST range when input dates are empty", () => {
+        const result = buildSuggestionSearchRange({}, now);
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+        expect(result.range.start.toISOString()).toBe(
+            "2026-06-18T15:00:00.000Z",
+        );
+        expect(result.range.end.toISOString()).toBe("2026-07-02T14:59:59.999Z");
+    });
+
+    it("should build a custom JST date range", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026-07-10",
+                searchEndDate: "2026-07-12",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+        expect(result.range.start.toISOString()).toBe(
+            "2026-07-09T15:00:00.000Z",
+        );
+        expect(result.range.end.toISOString()).toBe("2026-07-12T14:59:59.999Z");
+    });
+
+    it("should reject malformed date strings", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026/07/10",
+                searchEndDate: "2026-07-12",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject start dates before tomorrow", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026-06-18",
+                searchEndDate: "2026-06-20",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject end dates before start dates", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026-07-12",
+                searchEndDate: "2026-07-10",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject ranges longer than the maximum search days", () => {
+        const result = buildSuggestionSearchRange(
+            {
+                searchStartDate: "2026-07-01",
+                searchEndDate: "2026-09-01",
+            },
+            now,
+        );
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+        expect(result.error).toContain(String(MAX_SUGGESTION_SEARCH_DAYS));
+    });
+});

--- a/src/domain/__tests__/suggestion-search-range.test.ts
+++ b/src/domain/__tests__/suggestion-search-range.test.ts
@@ -1,7 +1,9 @@
 import {
     buildSuggestionSearchRange,
+    calculateMaxSearchEndDate,
     getDefaultSuggestionSearchDateValues,
     getInclusiveDateInputDayCount,
+    MAX_DATE_INPUT_VALUE,
     MAX_SUGGESTION_SEARCH_DAYS,
 } from "../suggestion-search-range";
 
@@ -28,6 +30,18 @@ describe("getInclusiveDateInputDayCount", () => {
     it("should return 1 when start and end are the same date", () => {
         expect(getInclusiveDateInputDayCount("2026-07-10", "2026-07-10")).toBe(
             1,
+        );
+    });
+});
+
+describe("calculateMaxSearchEndDate", () => {
+    it("should return the inclusive maximum end date from the start date", () => {
+        expect(calculateMaxSearchEndDate("2026-07-10")).toBe("2026-09-07");
+    });
+
+    it("should not return a date after the supported input maximum", () => {
+        expect(calculateMaxSearchEndDate("9999-12-31")).toBe(
+            MAX_DATE_INPUT_VALUE,
         );
     });
 });

--- a/src/domain/event.ts
+++ b/src/domain/event.ts
@@ -24,6 +24,8 @@ export interface EventDraft {
     title: string;
     duration: string;
     timeOfDayCandidate: EventTimeOfDay[];
+    searchStartDate?: string;
+    searchEndDate?: string;
     // 優先参加者をカンマ区切りで表す（例: "alice@example.com,bob@example.com"）
     priorityParticipants?: string;
     description: string;

--- a/src/domain/suggestion-search-range.ts
+++ b/src/domain/suggestion-search-range.ts
@@ -2,6 +2,7 @@ import type { TimeRange } from "./calendar";
 
 export const DEFAULT_SUGGESTION_SEARCH_DAYS = 14;
 export const MAX_SUGGESTION_SEARCH_DAYS = 60;
+export const MAX_DATE_INPUT_VALUE = "9999-12-31";
 
 type SuggestionSearchRangeInput = {
     searchStartDate?: string;
@@ -15,6 +16,7 @@ type SuggestionSearchRangeResult =
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const JST_OFFSET_HOURS = 9;
+const MAX_DATE_INPUT_TIME = Date.UTC(9999, 11, 31);
 
 export const getDefaultSuggestionSearchDateValues = (
     now: Date = new Date(),
@@ -87,6 +89,29 @@ export const getInclusiveDateInputDayCount = (
     const endTime = Date.UTC(endYear, endMonth - 1, endDay);
 
     return Math.floor((endTime - startTime) / DAY_MS) + 1;
+};
+
+export const calculateMaxSearchEndDate = (startDate: string): string => {
+    if (!DATE_ONLY_PATTERN.test(startDate)) {
+        return MAX_DATE_INPUT_VALUE;
+    }
+
+    const [year, month, day] = startDate.split("-").map(Number);
+    const startTime = Date.UTC(year, month - 1, day);
+    const maxEndDate = new Date(
+        startTime + (MAX_SUGGESTION_SEARCH_DAYS - 1) * DAY_MS,
+    );
+    if (maxEndDate.getTime() > MAX_DATE_INPUT_TIME) {
+        return MAX_DATE_INPUT_VALUE;
+    }
+
+    const maxEndDateInput = [
+        maxEndDate.getUTCFullYear(),
+        String(maxEndDate.getUTCMonth() + 1).padStart(2, "0"),
+        String(maxEndDate.getUTCDate()).padStart(2, "0"),
+    ].join("-");
+
+    return maxEndDateInput;
 };
 
 const parseJSTDateOnly = (

--- a/src/domain/suggestion-search-range.ts
+++ b/src/domain/suggestion-search-range.ts
@@ -1,0 +1,131 @@
+import type { TimeRange } from "./calendar";
+
+export const DEFAULT_SUGGESTION_SEARCH_DAYS = 14;
+export const MAX_SUGGESTION_SEARCH_DAYS = 60;
+
+type SuggestionSearchRangeInput = {
+    searchStartDate?: string;
+    searchEndDate?: string;
+};
+
+type SuggestionSearchRangeResult =
+    | { success: true; range: TimeRange }
+    | { success: false; error: string };
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const JST_OFFSET_HOURS = 9;
+
+export const getDefaultSuggestionSearchDateValues = (
+    now: Date = new Date(),
+): Required<SuggestionSearchRangeInput> => {
+    const tomorrow = addDays(startOfJSTDate(now), 1);
+    const defaultEnd = addDays(tomorrow, DEFAULT_SUGGESTION_SEARCH_DAYS - 1);
+
+    return {
+        searchStartDate: formatJSTDateInput(tomorrow),
+        searchEndDate: formatJSTDateInput(defaultEnd),
+    };
+};
+
+export const buildSuggestionSearchRange = (
+    input: SuggestionSearchRangeInput,
+    now: Date = new Date(),
+): SuggestionSearchRangeResult => {
+    const defaults = getDefaultSuggestionSearchDateValues(now);
+    const searchStartDate =
+        input.searchStartDate?.trim() || defaults.searchStartDate;
+    const searchEndDate = input.searchEndDate?.trim() || defaults.searchEndDate;
+
+    const start = parseJSTDateOnly(searchStartDate, "start");
+    const end = parseJSTDateOnly(searchEndDate, "end");
+
+    if (!start || !end) {
+        return {
+            success: false,
+            error: "検索期間は yyyy-MM-dd 形式の日付で指定してください",
+        };
+    }
+
+    const tomorrow = addDays(startOfJSTDate(now), 1);
+    if (start.getTime() < tomorrow.getTime()) {
+        return {
+            success: false,
+            error: "検索開始日は明日以降の日付を指定してください",
+        };
+    }
+
+    if (start.getTime() > end.getTime()) {
+        return {
+            success: false,
+            error: "検索終了日は検索開始日以降の日付を指定してください",
+        };
+    }
+
+    const selectedDays = getInclusiveJSTDayCount(start, end);
+    if (selectedDays > MAX_SUGGESTION_SEARCH_DAYS) {
+        return {
+            success: false,
+            error: `検索期間は最大${MAX_SUGGESTION_SEARCH_DAYS}日まで指定できます`,
+        };
+    }
+
+    return { success: true, range: { start, end } };
+};
+
+const parseJSTDateOnly = (
+    value: string,
+    boundary: "start" | "end",
+): Date | undefined => {
+    if (!DATE_ONLY_PATTERN.test(value)) {
+        return undefined;
+    }
+
+    const [year, month, day] = value.split("-").map(Number);
+    const date =
+        boundary === "start"
+            ? new Date(Date.UTC(year, month - 1, day, -JST_OFFSET_HOURS))
+            : new Date(
+                  Date.UTC(year, month - 1, day, 24 - JST_OFFSET_HOURS) - 1,
+              );
+
+    return formatJSTDateInput(date) === value ? date : undefined;
+};
+
+const startOfJSTDate = (date: Date): Date => {
+    const parts = getJSTDateParts(date);
+    return new Date(
+        Date.UTC(parts.year, parts.month - 1, parts.day, -JST_OFFSET_HOURS),
+    );
+};
+
+const addDays = (date: Date, days: number): Date =>
+    new Date(date.getTime() + days * DAY_MS);
+
+const getInclusiveJSTDayCount = (start: Date, end: Date): number => {
+    const startDay = startOfJSTDate(start);
+    const endDay = startOfJSTDate(end);
+    return Math.floor((endDay.getTime() - startDay.getTime()) / DAY_MS) + 1;
+};
+
+const formatJSTDateInput = (date: Date): string => {
+    const parts = getJSTDateParts(date);
+    return [
+        parts.year,
+        String(parts.month).padStart(2, "0"),
+        String(parts.day).padStart(2, "0"),
+    ].join("-");
+};
+
+const getJSTDateParts = (
+    date: Date,
+): { year: number; month: number; day: number } => {
+    const jstDate = new Date(
+        date.getTime() + JST_OFFSET_HOURS * 60 * 60 * 1000,
+    );
+    return {
+        year: jstDate.getUTCFullYear(),
+        month: jstDate.getUTCMonth() + 1,
+        day: jstDate.getUTCDate(),
+    };
+};

--- a/src/domain/suggestion-search-range.ts
+++ b/src/domain/suggestion-search-range.ts
@@ -62,7 +62,11 @@ export const buildSuggestionSearchRange = (
         };
     }
 
-    const selectedDays = getInclusiveJSTDayCount(start, end);
+    // end is exclusive, so subtract 1ms to count the selected end date itself.
+    const selectedDays = getInclusiveJSTDayCount(
+        start,
+        new Date(end.getTime() - 1),
+    );
     if (selectedDays > MAX_SUGGESTION_SEARCH_DAYS) {
         return {
             success: false,
@@ -71,6 +75,18 @@ export const buildSuggestionSearchRange = (
     }
 
     return { success: true, range: { start, end } };
+};
+
+export const getInclusiveDateInputDayCount = (
+    startDate: string,
+    endDate: string,
+): number => {
+    const [startYear, startMonth, startDay] = startDate.split("-").map(Number);
+    const [endYear, endMonth, endDay] = endDate.split("-").map(Number);
+    const startTime = Date.UTC(startYear, startMonth - 1, startDay);
+    const endTime = Date.UTC(endYear, endMonth - 1, endDay);
+
+    return Math.floor((endTime - startTime) / DAY_MS) + 1;
 };
 
 const parseJSTDateOnly = (
@@ -85,11 +101,12 @@ const parseJSTDateOnly = (
     const date =
         boundary === "start"
             ? new Date(Date.UTC(year, month - 1, day, -JST_OFFSET_HOURS))
-            : new Date(
-                  Date.UTC(year, month - 1, day, 24 - JST_OFFSET_HOURS) - 1,
-              );
+            : new Date(Date.UTC(year, month - 1, day, 24 - JST_OFFSET_HOURS));
 
-    return formatJSTDateInput(date) === value ? date : undefined;
+    const dateToValidate =
+        boundary === "start" ? date : new Date(date.getTime() - 1);
+
+    return formatJSTDateInput(dateToValidate) === value ? date : undefined;
 };
 
 const startOfJSTDate = (date: Date): Date => {

--- a/src/domain/suggestion-search-range.ts
+++ b/src/domain/suggestion-search-range.ts
@@ -55,7 +55,7 @@ export const buildSuggestionSearchRange = (
         };
     }
 
-    if (start.getTime() > end.getTime()) {
+    if (start.getTime() >= end.getTime()) {
         return {
             success: false,
             error: "検索終了日は検索開始日以降の日付を指定してください",


### PR DESCRIPTION
## 概要

候補検索期間を、固定の「明日〜14日後」からフォーム入力で指定できるようにしました。

既存挙動に近いデフォルトとして、初期値は「明日〜14日後」にしています。未入力や不正値はサーバー側でも検証し、Google Calendar取得量と生成スロット数が増えすぎないよう最大60日までに制限しています。

## 変更内容

- 作成フォームに候補検索期間の開始日・終了日入力を追加
- `EventDraft` に `searchStartDate` / `searchEndDate` を追加
- `getScheduleSuggestionsAction` の固定期間生成を廃止し、入力された検索期間から `scheduleRange` を作成
- JSTの日付入力を `TimeRange` に変換するdomain helperを追加
- 検索期間のvalidationを追加
  - 開始日は明日以降
  - 終了日は開始日以降
  - 最大60日まで
- 終了日境界は end-exclusive として、終了日の翌日 `00:00 JST` を `range.end` に設定
- UI側でも最大日数などを検証し、submit後に初めて弾かれるケースを減らす
- 日付範囲計算のテストを追加

## 補足

祝日情報の取得やGeminiへの祝日情報の受け渡しは、このPRには含めません。  
候補検索期間が任意指定できるようになった後のPR3.6相当で、Google Calendarの日本の祝日カレンダーを `events.list` で取得し、Gemini promptの補助情報として渡す方針で検討します。

## 確認

- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “候補検索期間” start/end date inputs to the event creation form, including automatic default values, dynamic min/max constraints, and validation for allowed range length.
  * Scheduling suggestion generation now respects the chosen candidate search date window when computing suggested free time.
* **Tests**
  * Added/extended Jest coverage for default date derivation, JST date handling, max-end-date calculation, and validation scenarios (format, ordering, and range-limit enforcement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->