### PR TITLE
feat: 祝日情報を希望条件抽出に渡す

### DIFF
--- a/src/app/(auth)/ai-suggest/page.tsx
+++ b/src/app/(auth)/ai-suggest/page.tsx
@@ -5,11 +5,15 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { formatToJST } from "@/lib/date";
 import { createEventAction } from "@/app/(auth)/create-event/actions";
+import {
+    ScheduleSuggestion,
+    ScheduleSuggestionSection,
+} from "@/domain/schedule-suggestion";
 
 interface EventSession {
     groupId: string;
     draft: { title: string; description: string };
-    suggestions: { start: string; end: string; reason: string }[];
+    sections: ScheduleSuggestionSection[];
 }
 
 const SESSION_KEY = "lablink_event_session";
@@ -29,15 +33,12 @@ export default function AISuggestPage() {
                 return;
             }
             const parsed = JSON.parse(raw) as EventSession;
-            if (
-                !parsed.groupId ||
-                !parsed.draft ||
-                !Array.isArray(parsed.suggestions)
-            ) {
+            const sections = normalizeSuggestionSections(parsed);
+            if (!isValidSession(parsed) || !sections) {
                 router.replace("/group");
                 return;
             }
-            setSession(parsed);
+            setSession({ ...parsed, sections });
         } catch {
             router.replace("/group");
         }
@@ -51,7 +52,19 @@ export default function AISuggestPage() {
         );
     }
 
-    if (session.suggestions.length === 0) {
+    const suggestions = session.sections.flatMap(
+        (section) => section.suggestions,
+    );
+    const getSuggestionIndex = (
+        sectionIndex: number,
+        suggestionIndex: number,
+    ): number =>
+        session.sections
+            .slice(0, sectionIndex)
+            .reduce((sum, section) => sum + section.suggestions.length, 0) +
+        suggestionIndex;
+
+    if (suggestions.length === 0) {
         return (
             <div className="min-h-screen bg-white">
                 <div className="flex flex-col items-center justify-center min-h-screen">
@@ -82,7 +95,7 @@ export default function AISuggestPage() {
         setError(null);
         setIsConfirming(true);
         try {
-            const suggestion = session.suggestions[selectedIndex];
+            const suggestion = suggestions[selectedIndex];
             const result = await createEventAction(session.groupId, {
                 title: session.draft.title,
                 description: session.draft.description,
@@ -124,45 +137,93 @@ export default function AISuggestPage() {
 
             <div className="flex justify-center py-8">
                 <div className="w-4/5 max-w-5xl">
-                    <div className="space-y-9 mb-8">
-                        {session.suggestions.map((s, idx) => {
-                            const start = new Date(s.start);
-                            const end = new Date(s.end);
-                            const dateStr = formatToJST(start, "yyyy/MM/dd");
-                            const startTime = formatToJST(start, "HH:mm");
-                            const endTime = formatToJST(end, "HH:mm");
-
-                            return (
-                                <div
-                                    key={idx}
-                                    role="button"
-                                    tabIndex={0}
-                                    aria-pressed={selectedIndex === idx}
-                                    onClick={() => setSelectedIndex(idx)}
-                                    onKeyDown={(e) => {
-                                        if (
-                                            e.key === "Enter" ||
-                                            e.key === " "
-                                        ) {
-                                            e.preventDefault();
-                                            setSelectedIndex(idx);
-                                        }
-                                    }}
-                                    className={`p-6 rounded-lg cursor-pointer transition-colors ${
-                                        selectedIndex === idx
-                                            ? "bg-blue-100 border-2 border-blue-500"
-                                            : "bg-gray-100 hover:bg-gray-200"
-                                    }`}
-                                >
-                                    <p className="text-black font-bold text-center text-xl">
-                                        {dateStr} {startTime}～{endTime}
-                                    </p>
-                                    <p className="text-gray-600 text-sm text-center mt-2">
-                                        {s.reason}
+                    <div className="space-y-10 mb-8">
+                        {session.sections.map((section, sectionIndex) => (
+                            <section key={section.kind} className="space-y-4">
+                                <div>
+                                    <h2 className="text-2xl font-bold text-black">
+                                        {section.title}
+                                    </h2>
+                                    <p className="text-gray-600 mt-1">
+                                        {section.description}
                                     </p>
                                 </div>
-                            );
-                        })}
+                                {section.suggestions.length === 0 ? (
+                                    <p className="text-gray-500">
+                                        この条件に合う候補はありません。
+                                    </p>
+                                ) : (
+                                    <div className="space-y-5">
+                                        {section.suggestions.map(
+                                            (s, suggestionIndex) => {
+                                                const idx = getSuggestionIndex(
+                                                    sectionIndex,
+                                                    suggestionIndex,
+                                                );
+                                                const start = new Date(s.start);
+                                                const end = new Date(s.end);
+                                                const dateStr = formatToJST(
+                                                    start,
+                                                    "yyyy/MM/dd",
+                                                );
+                                                const startTime = formatToJST(
+                                                    start,
+                                                    "HH:mm",
+                                                );
+                                                const endTime = formatToJST(
+                                                    end,
+                                                    "HH:mm",
+                                                );
+
+                                                return (
+                                                    <div
+                                                        key={`${s.start}-${s.end}`}
+                                                        role="button"
+                                                        tabIndex={0}
+                                                        aria-pressed={
+                                                            selectedIndex ===
+                                                            idx
+                                                        }
+                                                        onClick={() =>
+                                                            setSelectedIndex(
+                                                                idx,
+                                                            )
+                                                        }
+                                                        onKeyDown={(e) => {
+                                                            if (
+                                                                e.key ===
+                                                                    "Enter" ||
+                                                                e.key === " "
+                                                            ) {
+                                                                e.preventDefault();
+                                                                setSelectedIndex(
+                                                                    idx,
+                                                                );
+                                                            }
+                                                        }}
+                                                        className={`p-6 rounded-lg cursor-pointer transition-colors ${
+                                                            selectedIndex ===
+                                                            idx
+                                                                ? "bg-blue-100 border-2 border-blue-500"
+                                                                : "bg-gray-100 hover:bg-gray-200"
+                                                        }`}
+                                                    >
+                                                        <p className="text-black font-bold text-center text-xl">
+                                                            {dateStr}{" "}
+                                                            {startTime}～
+                                                            {endTime}
+                                                        </p>
+                                                        <p className="text-gray-600 text-sm text-center mt-2">
+                                                            {s.reason}
+                                                        </p>
+                                                    </div>
+                                                );
+                                            },
+                                        )}
+                                    </div>
+                                )}
+                            </section>
+                        ))}
                     </div>
 
                     {error && (
@@ -188,4 +249,79 @@ export default function AISuggestPage() {
             </div>
         </div>
     );
+}
+
+function normalizeSuggestionSections(
+    value: unknown,
+): ScheduleSuggestionSection[] | null {
+    if (!isObject(value)) {
+        return null;
+    }
+
+    if (Array.isArray(value.sections) && value.sections.every(isSection)) {
+        return value.sections;
+    }
+
+    if (
+        Array.isArray(value.suggestions) &&
+        value.suggestions.every(isSuggestion)
+    ) {
+        return [
+            {
+                kind: "preferred",
+                title: "希望時間帯の候補",
+                description: "入力内容と選択した時間帯に沿った候補です。",
+                suggestions: value.suggestions,
+            },
+        ];
+    }
+
+    return null;
+}
+
+function isSection(value: unknown): value is ScheduleSuggestionSection {
+    return (
+        isObject(value) &&
+        (value.kind === "preferred" || value.kind === "fallback") &&
+        typeof value.title === "string" &&
+        typeof value.description === "string" &&
+        Array.isArray(value.suggestions) &&
+        value.suggestions.every(isSuggestion)
+    );
+}
+
+function isSuggestion(value: unknown): value is ScheduleSuggestion {
+    return (
+        isObject(value) &&
+        isParseableDateString(value.start) &&
+        isParseableDateString(value.end) &&
+        typeof value.reason === "string"
+    );
+}
+
+function isValidSession(value: unknown): value is EventSession {
+    return (
+        isObject(value) &&
+        typeof value.groupId === "string" &&
+        value.groupId.length > 0 &&
+        isDraft(value.draft)
+    );
+}
+
+function isDraft(
+    value: unknown,
+): value is { title: string; description: string } {
+    return (
+        isObject(value) &&
+        typeof value.title === "string" &&
+        typeof value.description === "string"
+    );
+}
+
+function isParseableDateString(value: unknown): value is string {
+    return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
 }

--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -97,7 +97,7 @@ export default function CreateEventForm({ groupId, users }: Props) {
                                 title: data.title,
                                 description: data.description,
                             },
-                            suggestions: result.suggestions,
+                            sections: result.sections,
                         }),
                     );
                 } catch (storageErr) {

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -22,9 +22,14 @@ import {
     EventMember,
     findMatchingPreferredHourRange,
     SchedulePreference,
-    selectDiverseTopN,
+    selectPreferredAndFallbackScores,
     TimeRangeScore,
 } from "@/domain/schedule-calculator";
+import {
+    ScheduleSuggestion,
+    ScheduleSuggestionSection,
+    ScheduleSuggestionSectionKind,
+} from "@/domain/schedule-suggestion";
 
 export async function getScheduleSuggestionsAction(
     groupId: string,
@@ -32,7 +37,7 @@ export async function getScheduleSuggestionsAction(
 ): Promise<
     | {
           success: true;
-          suggestions: { start: string; end: string; reason: string }[];
+          sections: ScheduleSuggestionSection[];
       }
     | { success: false; error: string }
 > {
@@ -142,7 +147,8 @@ export async function getScheduleSuggestionsAction(
             scheduleRange,
             durationMinutes,
             members,
-            allowedHourRanges,
+            // UI時間帯フィルタは候補分割時に適用するため、ここでは全スロットを生成する。
+            undefined,
             schedulePreference,
         );
 
@@ -156,19 +162,20 @@ export async function getScheduleSuggestionsAction(
         }
 
         const requiredCount = members.filter((m) => m.isRequired).length;
-        const suggestions = selectDiverseTopN(scoresResult.value, 3);
+        const suggestionScores = selectPreferredAndFallbackScores(
+            scoresResult.value,
+            3,
+            allowedHourRanges,
+            requiredCount,
+        );
 
         return {
             success: true,
-            suggestions: suggestions.map((s) => ({
-                start: s.timeRange.start.toISOString(),
-                end: s.timeRange.end.toISOString(),
-                reason: createSuggestionReason(
-                    s,
-                    requiredCount,
-                    schedulePreference,
-                ),
-            })),
+            sections: createSuggestionSections(
+                suggestionScores,
+                requiredCount,
+                schedulePreference,
+            ),
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -184,6 +191,7 @@ const createSuggestionReason = (
     score: TimeRangeScore,
     requiredCount: number,
     schedulePreference: SchedulePreference | undefined,
+    sectionKind: ScheduleSuggestionSectionKind,
 ): string => {
     const displayStart = formatToJST(score.timeRange.start, "M月d日 H:mm");
     const allRequiredMembersAvailable =
@@ -200,10 +208,72 @@ const createSuggestionReason = (
         : undefined;
     const preferenceText = matchingHourRange
         ? `入力内容から抽出した希望も加味しています。${matchingHourRange.reason}`
-        : "希望時間帯の中から参加可能性をもとに選んでいます。";
+        : sectionKind === "fallback"
+          ? "希望時間帯からは外れますが、参加可能性を優先して提示しています。"
+          : "希望時間帯の中から参加可能性をもとに選んでいます。";
 
     return `${availabilityText}${preferenceText}`;
 };
+
+const createSuggestionSections = (
+    scores: {
+        preferred: TimeRangeScore[];
+        fallback: TimeRangeScore[];
+    },
+    requiredCount: number,
+    schedulePreference: SchedulePreference | undefined,
+): ScheduleSuggestionSection[] => {
+    const sections: ScheduleSuggestionSection[] = [
+        {
+            kind: "preferred",
+            title: "希望時間帯の候補",
+            description: "入力内容と選択した時間帯に沿った候補です。",
+            suggestions: scores.preferred.map((score) =>
+                createSuggestion(
+                    score,
+                    requiredCount,
+                    schedulePreference,
+                    "preferred",
+                ),
+            ),
+        },
+    ];
+
+    if (scores.fallback.length > 0) {
+        sections.push({
+            kind: "fallback",
+            title: "参加可能性を優先した候補",
+            description:
+                "希望時間帯では必須メンバーの都合が合いにくいため、別時間帯の候補も表示しています。",
+            suggestions: scores.fallback.map((score) =>
+                createSuggestion(
+                    score,
+                    requiredCount,
+                    schedulePreference,
+                    "fallback",
+                ),
+            ),
+        });
+    }
+
+    return sections;
+};
+
+const createSuggestion = (
+    score: TimeRangeScore,
+    requiredCount: number,
+    schedulePreference: SchedulePreference | undefined,
+    sectionKind: ScheduleSuggestionSectionKind,
+): ScheduleSuggestion => ({
+    start: score.timeRange.start.toISOString(),
+    end: score.timeRange.end.toISOString(),
+    reason: createSuggestionReason(
+        score,
+        requiredCount,
+        schedulePreference,
+        sectionKind,
+    ),
+});
 
 export async function createEventAction(
     groupId: string,

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -8,7 +8,10 @@ import { EVENT_TIME_OF_DAY_CONFIG } from "@/domain/event";
 import { revalidatePath } from "next/cache";
 import { parseDuration } from "@/lib/event-to-draft";
 import { findUsersByIds } from "@/infra/user/user-admin-repo";
-import { googleCalendarRepository } from "@/infra/calendar/google-calendar-repo";
+import {
+    googleCalendarRepository,
+    googleHolidayRepository,
+} from "@/infra/calendar/google-calendar-repo";
 import { googleTokenRepository } from "@/infra/token/google-token-repo";
 import { geminiRepo } from "@/infra/ai/gemini-repo";
 import { createCalculateFreeTimeService } from "@/service/calculate-free-time-service";
@@ -103,9 +106,24 @@ export async function getScheduleSuggestionsAction(
                 ? validCandidates.map((t) => EVENT_TIME_OF_DAY_CONFIG[t].hours)
                 : undefined;
 
+        const holidaysResult =
+            await googleHolidayRepository.fetchJapaneseHolidays(
+                userId,
+                scheduleRange.start,
+                scheduleRange.end,
+                googleTokenRepository,
+            );
+        const holidays = holidaysResult.isOk() ? holidaysResult.value : [];
+        if (holidaysResult.isErr()) {
+            console.warn(
+                "Failed to fetch Japanese holidays:",
+                holidaysResult.error.message,
+            );
+        }
+
         const preferenceResult = await createSchedulePreferenceService(
             geminiRepo,
-        ).extractPreference(draft.description, validCandidates);
+        ).extractPreference(draft.description, validCandidates, holidays);
 
         const schedulePreference = preferenceResult.isOk()
             ? preferenceResult.value

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -5,6 +5,7 @@ import {
     calculateSchedulePreferenceScore,
     EventMember,
     findMatchingPreferredHourRange,
+    selectPreferredAndFallbackScores,
     SchedulePreferenceSchema,
     selectDiverseTopN,
 } from "../schedule-calculator";
@@ -596,5 +597,241 @@ describe("selectDiverseTopN", () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].score).toBe(13);
+    });
+});
+
+describe("selectPreferredAndFallbackScores", () => {
+    const createScore = (
+        start: string,
+        end: string,
+        required: string[],
+        score: number,
+    ) => ({
+        timeRange: {
+            start: new Date(start),
+            end: new Date(end),
+        },
+        availableMemberIds: { required, optional: [] },
+        score,
+    });
+
+    it("should return fallback candidates only when they improve required member availability", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T08:00:00.000Z",
+                "2026-02-27T09:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 17:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.preferred[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T03:00:00.000Z",
+        );
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T08:00:00.000Z",
+        );
+    });
+
+    it("should not return fallback candidates that are far from the selected UI hour range", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should include fallback candidates exactly three hours after the selected UI hour range", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T09:00:00.000Z",
+                "2026-02-27T10:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 18:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T09:00:00.000Z",
+        );
+    });
+
+    it("should include fallback candidates that start at 22:00", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 19:00
+            createScore(
+                "2026-02-27T13:00:00.000Z",
+                "2026-02-27T14:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 22:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 18, end: 22 }],
+            2,
+        );
+
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T13:00:00.000Z",
+        );
+    });
+
+    it("should not return late-night fallback candidates", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 19:00
+            createScore(
+                "2026-02-27T17:00:00.000Z",
+                "2026-02-27T18:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 02:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 18, end: 22 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates when required member availability does not improve", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                23,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates with no required member availability when preferred candidates are empty", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                [],
+                0,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(0);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates when no UI hour range is specified", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ),
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ),
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            undefined,
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(2);
+        expect(result.fallback).toHaveLength(0);
     });
 });

--- a/src/domain/holiday.ts
+++ b/src/domain/holiday.ts
@@ -1,0 +1,17 @@
+import { ResultAsync } from "neverthrow";
+import { CalendarError } from "./calendar";
+import { TokenRepository } from "./token";
+
+export interface Holiday {
+    date: string;
+    name: string;
+}
+
+export interface HolidayRepository {
+    fetchJapaneseHolidays(
+        userId: string,
+        timeMin: Date,
+        timeMax: Date,
+        tokenRepository: TokenRepository,
+    ): ResultAsync<Holiday[], CalendarError>;
+}

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -14,6 +14,10 @@ export const MEMBER_REQUIRED_SCORE = 10;
 export const MEMBER_OPTIONAL_SCORE = 1;
 export const SCHEDULE_PREFERENCE_DAY_SCORE = 1;
 export const SCHEDULE_PREFERENCE_HOUR_RANGE_SCORE = 2;
+const FALLBACK_CANDIDATE_MIN_START_HOUR = 8;
+const FALLBACK_CANDIDATE_MAX_START_HOUR = 22;
+const FALLBACK_CANDIDATE_MAX_END_HOUR = FALLBACK_CANDIDATE_MAX_START_HOUR + 1;
+const FALLBACK_CANDIDATE_HOUR_RANGE_PADDING = 3;
 
 export const SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES = [
     "sunday",
@@ -94,6 +98,11 @@ export interface TimeRangeScore {
     score: number;
 }
 
+export interface PreferredFallbackScoreSections {
+    preferred: TimeRangeScore[];
+    fallback: TimeRangeScore[];
+}
+
 /**
  * 指定された時間帯に、指定された間隔でタイムスロットを作成する。
  * @param timeRange 時間帯
@@ -151,11 +160,12 @@ export const createSlots = (
         // 時間帯フィルタ: 指定されている場合、開始時刻（JST）がいずれかの
         // 許可範囲に含まれるスロットのみ生成する
         if (allowedHourRanges) {
-            const hourJST = (currentStart.getUTCHours() + 9) % 24;
-            const isAllowed = allowedHourRanges.some(
-                (range) => hourJST >= range.start && hourJST < range.end,
-            );
-            if (!isAllowed) {
+            if (
+                !isTimeRangeStartInAllowedHourRanges(
+                    { start: currentStart, end: currentEnd },
+                    allowedHourRanges,
+                )
+            ) {
                 currentStart = new Date(
                     currentStart.getTime() + slotIntervalMs,
                 );
@@ -294,6 +304,108 @@ export const selectDiverseTopN = (
     }
 
     return selected;
+};
+
+export const selectPreferredAndFallbackScores = (
+    scores: TimeRangeScore[],
+    n: number,
+    allowedHourRanges: { start: number; end: number }[] | undefined,
+    requiredCount: number,
+): PreferredFallbackScoreSections => {
+    const hasHourRangeConstraint =
+        allowedHourRanges !== undefined && allowedHourRanges.length > 0;
+    const preferredCandidates = hasHourRangeConstraint
+        ? scores.filter((score) =>
+              isTimeRangeStartInAllowedHourRanges(
+                  score.timeRange,
+                  allowedHourRanges,
+              ),
+          )
+        : scores;
+    const preferred = selectDiverseTopN(preferredCandidates, n);
+
+    if (!hasHourRangeConstraint || requiredCount === 0) {
+        return { preferred, fallback: [] };
+    }
+
+    const maxPreferredRequiredCount =
+        preferred.length > 0
+            ? Math.max(
+                  ...preferred.map(
+                      (score) => score.availableMemberIds.required.length,
+                  ),
+              )
+            : 0;
+    const fallbackAllowedHourRanges =
+        createFallbackAllowedHourRanges(allowedHourRanges);
+    const fallbackCandidates = scores.filter(
+        (score) =>
+            !isTimeRangeStartInAllowedHourRanges(
+                score.timeRange,
+                allowedHourRanges,
+            ) &&
+            isTimeRangeStartInAllowedHourRanges(
+                score.timeRange,
+                fallbackAllowedHourRanges,
+            ) &&
+            score.availableMemberIds.required.length >
+                maxPreferredRequiredCount,
+    );
+
+    return {
+        preferred,
+        fallback: selectDiverseTopN(fallbackCandidates, n),
+    };
+};
+
+export const isTimeRangeStartInAllowedHourRanges = (
+    timeRange: TimeRange,
+    allowedHourRanges: { start: number; end: number }[] | undefined,
+): boolean => {
+    if (!allowedHourRanges || allowedHourRanges.length === 0) {
+        return true;
+    }
+
+    const hourJST = getJSTHour(timeRange.start);
+    return allowedHourRanges.some(
+        (range) => hourJST >= range.start && hourJST < range.end,
+    );
+};
+
+const createFallbackAllowedHourRanges = (
+    allowedHourRanges: { start: number; end: number }[],
+): { start: number; end: number }[] =>
+    mergeHourRanges(
+        allowedHourRanges.flatMap((range) => {
+            const start = Math.max(
+                FALLBACK_CANDIDATE_MIN_START_HOUR,
+                range.start - FALLBACK_CANDIDATE_HOUR_RANGE_PADDING,
+            );
+            const end = Math.min(
+                FALLBACK_CANDIDATE_MAX_END_HOUR,
+                range.end + FALLBACK_CANDIDATE_HOUR_RANGE_PADDING + 1,
+            );
+
+            return start < end ? [{ start, end }] : [];
+        }),
+    );
+
+const mergeHourRanges = (
+    ranges: { start: number; end: number }[],
+): { start: number; end: number }[] => {
+    const sortedRanges = [...ranges].sort((a, b) => a.start - b.start);
+    const mergedRanges: { start: number; end: number }[] = [];
+
+    for (const range of sortedRanges) {
+        const previous = mergedRanges.at(-1);
+        if (previous && range.start <= previous.end) {
+            previous.end = Math.max(previous.end, range.end);
+        } else {
+            mergedRanges.push({ ...range });
+        }
+    }
+
+    return mergedRanges;
 };
 
 const matchesPreferredDay = (

--- a/src/domain/schedule-suggestion.ts
+++ b/src/domain/schedule-suggestion.ts
@@ -1,0 +1,14 @@
+export type ScheduleSuggestionSectionKind = "preferred" | "fallback";
+
+export interface ScheduleSuggestion {
+    start: string;
+    end: string;
+    reason: string;
+}
+
+export interface ScheduleSuggestionSection {
+    kind: ScheduleSuggestionSectionKind;
+    title: string;
+    description: string;
+    suggestions: ScheduleSuggestion[];
+}

--- a/src/infra/calendar/google-calendar-repo.ts
+++ b/src/infra/calendar/google-calendar-repo.ts
@@ -13,6 +13,12 @@ import {
     toCalendarError,
 } from "./google-calendar-converter";
 import { decryptToken, Token } from "@/domain/token";
+import { HolidayRepository } from "@/domain/holiday";
+
+// Google Calendar の日本の祝日カレンダーID。
+// 祝日は freebusy には混ぜず、events.list で補助情報としてだけ取得する。
+const JAPANESE_HOLIDAY_CALENDAR_ID =
+    "ja.japanese#holiday@group.v.calendar.google.com";
 
 const initCalendar = (userId: string, token: Token) => {
     const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
@@ -83,4 +89,40 @@ export const googleCalendarRepository: CalendarRepository = {
                             ) || [],
                 ),
             })),
+};
+
+export const googleHolidayRepository: HolidayRepository = {
+    fetchJapaneseHolidays: (userId, timeMin, timeMax, tokenRepository) =>
+        tokenRepository
+            .get(userId, "google")
+            .andThen(decryptToken)
+            .andThen((token) => initCalendar(userId, token))
+            .andThen((calendar) =>
+                ResultAsync.fromPromise(
+                    calendar.events.list({
+                        calendarId: JAPANESE_HOLIDAY_CALENDAR_ID,
+                        timeMin: timeMin.toISOString(),
+                        timeMax: timeMax.toISOString(),
+                        timeZone: "Asia/Tokyo",
+                        singleEvents: true,
+                        orderBy: "startTime",
+                    }),
+                    (error) => {
+                        const _error =
+                            error as GaxiosError<GoogleCalendarErrorResponse>;
+                        return toCalendarError(_error, userId, [
+                            JAPANESE_HOLIDAY_CALENDAR_ID,
+                        ]);
+                    },
+                ),
+            )
+            .map((response) =>
+                (response.data.items ?? []).flatMap((event) => {
+                    const date = event.start?.date;
+                    const name = event.summary;
+                    return typeof date === "string" && typeof name === "string"
+                        ? [{ date, name }]
+                        : [];
+                }),
+            ),
 };

--- a/src/service/__tests__/schedule-preference-service.test.ts
+++ b/src/service/__tests__/schedule-preference-service.test.ts
@@ -75,6 +75,23 @@ describe("generateSchedulePreferencePrompt", () => {
 
         expect(descriptionBlock).toHaveLength(2000);
     });
+    it("should include Japanese holidays as reference-only context", () => {
+        const prompt = generateSchedulePreferencePrompt(
+            "懇親会",
+            ["night"],
+            [{ date: "2026-07-20", name: "海の日" }],
+        );
+
+        expect(prompt).toContain("Japanese Public Holidays in Search Range");
+        expect(prompt).toContain("2026-07-20 (月): 海の日");
+        expect(prompt).toContain("reference data only");
+        expect(prompt).toContain(
+            "do not recommend a day only because it is a holiday",
+        );
+        expect(prompt).toContain(
+            "Actual participant availability is more important",
+        );
+    });
 });
 
 describe("SchedulePreferenceService", () => {
@@ -114,6 +131,7 @@ describe("SchedulePreferenceService", () => {
             const result = await service.extractPreference(
                 "研究室の歓迎会をしたい",
                 ["noon"],
+                [],
             );
 
             expect(result.isOk()).toBe(true);
@@ -126,6 +144,28 @@ describe("SchedulePreferenceService", () => {
             expect(callArgs[0]).toContain("研究室の歓迎会をしたい");
             expect(callArgs[0]).toContain("JST 12:00-15:00");
             expect(callArgs[1]).toBe(SchedulePreferenceSchema);
+        });
+
+        it("should pass holidays into the generated prompt", async () => {
+            const mockPreference = {
+                dayWeights: [],
+                hourRangeWeights: [],
+                summary: "祝日情報を参考にします。",
+            };
+            mockGenAIRepo.generateStructured.mockReturnValue(
+                okAsync(mockPreference),
+            );
+
+            const service = createSchedulePreferenceService(mockGenAIRepo);
+            await service.extractPreference(
+                "party",
+                ["night"],
+                [{ date: "2026-07-20", name: "海の日" }],
+            );
+
+            const callArgs = mockGenAIRepo.generateStructured.mock.calls[0];
+            expect(callArgs[0]).toContain("2026-07-20");
+            expect(callArgs[0]).toContain("海の日");
         });
 
         it("should forward GenAI errors", async () => {
@@ -141,6 +181,7 @@ describe("SchedulePreferenceService", () => {
             const result = await service.extractPreference(
                 "研究室の歓迎会をしたい",
                 ["noon"],
+                [],
             );
 
             expect(result.isErr()).toBe(true);

--- a/src/service/schedule-preference-service.ts
+++ b/src/service/schedule-preference-service.ts
@@ -8,8 +8,10 @@ import {
     SchedulePreferenceSchema,
 } from "@/domain/schedule-calculator";
 import { createGenAIService } from "./gen-ai-service";
+import { Holiday } from "@/domain/holiday";
 
 const MAX_DESCRIPTION_LENGTH = 2000;
+const WEEKDAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
 
 export interface SchedulePreferenceService {
     /**
@@ -22,12 +24,14 @@ export interface SchedulePreferenceService {
     extractPreference(
         description: string,
         timeOfDayCandidates: EventTimeOfDay[],
+        holidays: Holiday[],
     ): ResultAsync<SchedulePreference, GenAIError>;
 }
 
 export function generateSchedulePreferencePrompt(
     description: string,
     timeOfDayCandidates: EventTimeOfDay[],
+    holidays: Holiday[] = [],
 ): string {
     const sanitizedDescription = sanitizeEventDescription(description);
 
@@ -49,6 +53,8 @@ export function generateSchedulePreferencePrompt(
                   .join("\n")
             : "- 指定なし";
 
+    const holidayText = formatHolidayContext(holidays);
+
     return `You are a schedule preference extraction AI.
 Extract preferred days of week and preferred JST hour ranges from the event description and UI-selected time ranges.
 
@@ -60,6 +66,10 @@ DATA_END
 
 【UI-selected Time Ranges】
 ${timeOfDayText}
+
+Japanese Public Holidays in Search Range:
+These holidays are reference data only. Use them to understand event context, but do not recommend a day only because it is a holiday. Actual participant availability is more important.
+${holidayText}
 
 【Rules】
 - Treat UI-selected time ranges as strong constraints for preference extraction.
@@ -88,17 +98,46 @@ function sanitizeEventDescription(description: string): string {
         .slice(0, MAX_DESCRIPTION_LENGTH);
 }
 
+function formatHolidayContext(holidays: Holiday[]): string {
+    if (holidays.length === 0) {
+        return "- None";
+    }
+
+    return holidays.map(formatHoliday).join("\n");
+}
+
+function formatHoliday(holiday: Holiday): string {
+    const weekday = getWeekdayLabel(holiday.date);
+    const weekdayText = weekday ? ` (${weekday})` : "";
+    return `- ${holiday.date}${weekdayText}: ${holiday.name}`;
+}
+
+function getWeekdayLabel(dateText: string): string | undefined {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateText);
+    if (!match) {
+        return undefined;
+    }
+
+    const [, year, month, day] = match;
+    // YYYY-MM-DD は祝日の終日イベントの日付なので、ローカルTZに寄せずUTC日付として曜日を求める。
+    const date = new Date(
+        Date.UTC(Number(year), Number(month) - 1, Number(day)),
+    );
+    return WEEKDAY_LABELS[date.getUTCDay()];
+}
+
 export const createSchedulePreferenceService = (
     genAIRepository: GenAIRepository,
 ): SchedulePreferenceService => {
     const genAIService = createGenAIService(genAIRepository);
 
     return {
-        extractPreference: (description, timeOfDayCandidates) =>
+        extractPreference: (description, timeOfDayCandidates, holidays) =>
             genAIService.generateStructured(
                 generateSchedulePreferencePrompt(
                     description,
                     timeOfDayCandidates,
+                    holidays,
                 ),
                 SchedulePreferenceSchema,
                 /* retryCount */ 2,


### PR DESCRIPTION
## 概要

候補検索期間内の日本の祝日情報をGoogle Calendarから取得し、Geminiによるスケジュール希望条件抽出の補助情報としてpromptへ渡すようにしました。

祝日はスコアリングには直接使わず、Geminiが曜日や時間帯の理由を考えるための参考情報として扱います。

## 変更内容

- `Holiday` / `HolidayRepository` をdomainに追加
- Google Calendarの日本の祝日カレンダーを `events.list` で取得する `googleHolidayRepository` を追加
- イベント作成時の候補検索期間に含まれる祝日を取得し、`SchedulePreferenceService` に渡すよう変更
- Gemini promptに祝日一覧を追加
- promptでは、祝日は参考情報であり、祝日だけを理由に強く推奨しないことを明記
- 祝日取得に失敗した場合はwarnログを出し、祝日情報なしで候補生成を続行
- prompt生成とservice連携のテストを追加

## 補足

祝日取得はGoogle Calendarの読み取り権限に依存しますが、取得に失敗した場合もスケジュール提案自体は止めず、祝日情報なしで続行します。

## 確認

- `corepack pnpm test`
- `corepack pnpm typecheck`
- `corepack pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule suggestions now incorporate Japanese public holidays when generating time-range preferences.
  * Suggestions are now organized into grouped sections (preferred vs fallback) with corresponding reason messaging.

* **Bug Fixes**
  * If holiday lookup fails, scheduling continues normally using available data.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->