### PR TITLE
feat: 候補提示を希望候補と譲歩候補に分ける

### DIFF
--- a/src/app/(auth)/ai-suggest/page.tsx
+++ b/src/app/(auth)/ai-suggest/page.tsx
@@ -5,11 +5,15 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { formatToJST } from "@/lib/date";
 import { createEventAction } from "@/app/(auth)/create-event/actions";
+import {
+    ScheduleSuggestion,
+    ScheduleSuggestionSection,
+} from "@/domain/schedule-suggestion";
 
 interface EventSession {
     groupId: string;
     draft: { title: string; description: string };
-    suggestions: { start: string; end: string; reason: string }[];
+    sections: ScheduleSuggestionSection[];
 }
 
 const SESSION_KEY = "lablink_event_session";
@@ -29,15 +33,12 @@ export default function AISuggestPage() {
                 return;
             }
             const parsed = JSON.parse(raw) as EventSession;
-            if (
-                !parsed.groupId ||
-                !parsed.draft ||
-                !Array.isArray(parsed.suggestions)
-            ) {
+            const sections = normalizeSuggestionSections(parsed);
+            if (!isValidSession(parsed) || !sections) {
                 router.replace("/group");
                 return;
             }
-            setSession(parsed);
+            setSession({ ...parsed, sections });
         } catch {
             router.replace("/group");
         }
@@ -51,7 +52,19 @@ export default function AISuggestPage() {
         );
     }
 
-    if (session.suggestions.length === 0) {
+    const suggestions = session.sections.flatMap(
+        (section) => section.suggestions,
+    );
+    const getSuggestionIndex = (
+        sectionIndex: number,
+        suggestionIndex: number,
+    ): number =>
+        session.sections
+            .slice(0, sectionIndex)
+            .reduce((sum, section) => sum + section.suggestions.length, 0) +
+        suggestionIndex;
+
+    if (suggestions.length === 0) {
         return (
             <div className="min-h-screen bg-white">
                 <div className="flex flex-col items-center justify-center min-h-screen">
@@ -82,7 +95,7 @@ export default function AISuggestPage() {
         setError(null);
         setIsConfirming(true);
         try {
-            const suggestion = session.suggestions[selectedIndex];
+            const suggestion = suggestions[selectedIndex];
             const result = await createEventAction(session.groupId, {
                 title: session.draft.title,
                 description: session.draft.description,
@@ -124,45 +137,93 @@ export default function AISuggestPage() {
 
             <div className="flex justify-center py-8">
                 <div className="w-4/5 max-w-5xl">
-                    <div className="space-y-9 mb-8">
-                        {session.suggestions.map((s, idx) => {
-                            const start = new Date(s.start);
-                            const end = new Date(s.end);
-                            const dateStr = formatToJST(start, "yyyy/MM/dd");
-                            const startTime = formatToJST(start, "HH:mm");
-                            const endTime = formatToJST(end, "HH:mm");
-
-                            return (
-                                <div
-                                    key={idx}
-                                    role="button"
-                                    tabIndex={0}
-                                    aria-pressed={selectedIndex === idx}
-                                    onClick={() => setSelectedIndex(idx)}
-                                    onKeyDown={(e) => {
-                                        if (
-                                            e.key === "Enter" ||
-                                            e.key === " "
-                                        ) {
-                                            e.preventDefault();
-                                            setSelectedIndex(idx);
-                                        }
-                                    }}
-                                    className={`p-6 rounded-lg cursor-pointer transition-colors ${
-                                        selectedIndex === idx
-                                            ? "bg-blue-100 border-2 border-blue-500"
-                                            : "bg-gray-100 hover:bg-gray-200"
-                                    }`}
-                                >
-                                    <p className="text-black font-bold text-center text-xl">
-                                        {dateStr} {startTime}～{endTime}
-                                    </p>
-                                    <p className="text-gray-600 text-sm text-center mt-2">
-                                        {s.reason}
+                    <div className="space-y-10 mb-8">
+                        {session.sections.map((section, sectionIndex) => (
+                            <section key={section.kind} className="space-y-4">
+                                <div>
+                                    <h2 className="text-2xl font-bold text-black">
+                                        {section.title}
+                                    </h2>
+                                    <p className="text-gray-600 mt-1">
+                                        {section.description}
                                     </p>
                                 </div>
-                            );
-                        })}
+                                {section.suggestions.length === 0 ? (
+                                    <p className="text-gray-500">
+                                        この条件に合う候補はありません。
+                                    </p>
+                                ) : (
+                                    <div className="space-y-5">
+                                        {section.suggestions.map(
+                                            (s, suggestionIndex) => {
+                                                const idx = getSuggestionIndex(
+                                                    sectionIndex,
+                                                    suggestionIndex,
+                                                );
+                                                const start = new Date(s.start);
+                                                const end = new Date(s.end);
+                                                const dateStr = formatToJST(
+                                                    start,
+                                                    "yyyy/MM/dd",
+                                                );
+                                                const startTime = formatToJST(
+                                                    start,
+                                                    "HH:mm",
+                                                );
+                                                const endTime = formatToJST(
+                                                    end,
+                                                    "HH:mm",
+                                                );
+
+                                                return (
+                                                    <div
+                                                        key={`${s.start}-${s.end}`}
+                                                        role="button"
+                                                        tabIndex={0}
+                                                        aria-pressed={
+                                                            selectedIndex ===
+                                                            idx
+                                                        }
+                                                        onClick={() =>
+                                                            setSelectedIndex(
+                                                                idx,
+                                                            )
+                                                        }
+                                                        onKeyDown={(e) => {
+                                                            if (
+                                                                e.key ===
+                                                                    "Enter" ||
+                                                                e.key === " "
+                                                            ) {
+                                                                e.preventDefault();
+                                                                setSelectedIndex(
+                                                                    idx,
+                                                                );
+                                                            }
+                                                        }}
+                                                        className={`p-6 rounded-lg cursor-pointer transition-colors ${
+                                                            selectedIndex ===
+                                                            idx
+                                                                ? "bg-blue-100 border-2 border-blue-500"
+                                                                : "bg-gray-100 hover:bg-gray-200"
+                                                        }`}
+                                                    >
+                                                        <p className="text-black font-bold text-center text-xl">
+                                                            {dateStr}{" "}
+                                                            {startTime}～
+                                                            {endTime}
+                                                        </p>
+                                                        <p className="text-gray-600 text-sm text-center mt-2">
+                                                            {s.reason}
+                                                        </p>
+                                                    </div>
+                                                );
+                                            },
+                                        )}
+                                    </div>
+                                )}
+                            </section>
+                        ))}
                     </div>
 
                     {error && (
@@ -188,4 +249,79 @@ export default function AISuggestPage() {
             </div>
         </div>
     );
+}
+
+function normalizeSuggestionSections(
+    value: unknown,
+): ScheduleSuggestionSection[] | null {
+    if (!isObject(value)) {
+        return null;
+    }
+
+    if (Array.isArray(value.sections) && value.sections.every(isSection)) {
+        return value.sections;
+    }
+
+    if (
+        Array.isArray(value.suggestions) &&
+        value.suggestions.every(isSuggestion)
+    ) {
+        return [
+            {
+                kind: "preferred",
+                title: "希望時間帯の候補",
+                description: "入力内容と選択した時間帯に沿った候補です。",
+                suggestions: value.suggestions,
+            },
+        ];
+    }
+
+    return null;
+}
+
+function isSection(value: unknown): value is ScheduleSuggestionSection {
+    return (
+        isObject(value) &&
+        (value.kind === "preferred" || value.kind === "fallback") &&
+        typeof value.title === "string" &&
+        typeof value.description === "string" &&
+        Array.isArray(value.suggestions) &&
+        value.suggestions.every(isSuggestion)
+    );
+}
+
+function isSuggestion(value: unknown): value is ScheduleSuggestion {
+    return (
+        isObject(value) &&
+        isParseableDateString(value.start) &&
+        isParseableDateString(value.end) &&
+        typeof value.reason === "string"
+    );
+}
+
+function isValidSession(value: unknown): value is EventSession {
+    return (
+        isObject(value) &&
+        typeof value.groupId === "string" &&
+        value.groupId.length > 0 &&
+        isDraft(value.draft)
+    );
+}
+
+function isDraft(
+    value: unknown,
+): value is { title: string; description: string } {
+    return (
+        isObject(value) &&
+        typeof value.title === "string" &&
+        typeof value.description === "string"
+    );
+}
+
+function isParseableDateString(value: unknown): value is string {
+    return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
 }

--- a/src/app/(auth)/create-event/CreateEventForm.tsx
+++ b/src/app/(auth)/create-event/CreateEventForm.tsx
@@ -97,7 +97,7 @@ export default function CreateEventForm({ groupId, users }: Props) {
                                 title: data.title,
                                 description: data.description,
                             },
-                            suggestions: result.suggestions,
+                            sections: result.sections,
                         }),
                     );
                 } catch (storageErr) {

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -22,9 +22,14 @@ import {
     EventMember,
     findMatchingPreferredHourRange,
     SchedulePreference,
-    selectDiverseTopN,
+    selectPreferredAndFallbackScores,
     TimeRangeScore,
 } from "@/domain/schedule-calculator";
+import {
+    ScheduleSuggestion,
+    ScheduleSuggestionSection,
+    ScheduleSuggestionSectionKind,
+} from "@/domain/schedule-suggestion";
 
 export async function getScheduleSuggestionsAction(
     groupId: string,
@@ -32,7 +37,7 @@ export async function getScheduleSuggestionsAction(
 ): Promise<
     | {
           success: true;
-          suggestions: { start: string; end: string; reason: string }[];
+          sections: ScheduleSuggestionSection[];
       }
     | { success: false; error: string }
 > {
@@ -142,7 +147,8 @@ export async function getScheduleSuggestionsAction(
             scheduleRange,
             durationMinutes,
             members,
-            allowedHourRanges,
+            // UI時間帯フィルタは候補分割時に適用するため、ここでは全スロットを生成する。
+            undefined,
             schedulePreference,
         );
 
@@ -156,19 +162,20 @@ export async function getScheduleSuggestionsAction(
         }
 
         const requiredCount = members.filter((m) => m.isRequired).length;
-        const suggestions = selectDiverseTopN(scoresResult.value, 3);
+        const suggestionScores = selectPreferredAndFallbackScores(
+            scoresResult.value,
+            3,
+            allowedHourRanges,
+            requiredCount,
+        );
 
         return {
             success: true,
-            suggestions: suggestions.map((s) => ({
-                start: s.timeRange.start.toISOString(),
-                end: s.timeRange.end.toISOString(),
-                reason: createSuggestionReason(
-                    s,
-                    requiredCount,
-                    schedulePreference,
-                ),
-            })),
+            sections: createSuggestionSections(
+                suggestionScores,
+                requiredCount,
+                schedulePreference,
+            ),
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -184,6 +191,7 @@ const createSuggestionReason = (
     score: TimeRangeScore,
     requiredCount: number,
     schedulePreference: SchedulePreference | undefined,
+    sectionKind: ScheduleSuggestionSectionKind,
 ): string => {
     const displayStart = formatToJST(score.timeRange.start, "M月d日 H:mm");
     const allRequiredMembersAvailable =
@@ -200,10 +208,72 @@ const createSuggestionReason = (
         : undefined;
     const preferenceText = matchingHourRange
         ? `入力内容から抽出した希望も加味しています。${matchingHourRange.reason}`
-        : "希望時間帯の中から参加可能性をもとに選んでいます。";
+        : sectionKind === "fallback"
+          ? "希望時間帯からは外れますが、参加可能性を優先して提示しています。"
+          : "希望時間帯の中から参加可能性をもとに選んでいます。";
 
     return `${availabilityText}${preferenceText}`;
 };
+
+const createSuggestionSections = (
+    scores: {
+        preferred: TimeRangeScore[];
+        fallback: TimeRangeScore[];
+    },
+    requiredCount: number,
+    schedulePreference: SchedulePreference | undefined,
+): ScheduleSuggestionSection[] => {
+    const sections: ScheduleSuggestionSection[] = [
+        {
+            kind: "preferred",
+            title: "希望時間帯の候補",
+            description: "入力内容と選択した時間帯に沿った候補です。",
+            suggestions: scores.preferred.map((score) =>
+                createSuggestion(
+                    score,
+                    requiredCount,
+                    schedulePreference,
+                    "preferred",
+                ),
+            ),
+        },
+    ];
+
+    if (scores.fallback.length > 0) {
+        sections.push({
+            kind: "fallback",
+            title: "参加可能性を優先した候補",
+            description:
+                "希望時間帯では必須メンバーの都合が合いにくいため、別時間帯の候補も表示しています。",
+            suggestions: scores.fallback.map((score) =>
+                createSuggestion(
+                    score,
+                    requiredCount,
+                    schedulePreference,
+                    "fallback",
+                ),
+            ),
+        });
+    }
+
+    return sections;
+};
+
+const createSuggestion = (
+    score: TimeRangeScore,
+    requiredCount: number,
+    schedulePreference: SchedulePreference | undefined,
+    sectionKind: ScheduleSuggestionSectionKind,
+): ScheduleSuggestion => ({
+    start: score.timeRange.start.toISOString(),
+    end: score.timeRange.end.toISOString(),
+    reason: createSuggestionReason(
+        score,
+        requiredCount,
+        schedulePreference,
+        sectionKind,
+    ),
+});
 
 export async function createEventAction(
     groupId: string,

--- a/src/domain/__tests__/schedule-calculator.test.ts
+++ b/src/domain/__tests__/schedule-calculator.test.ts
@@ -5,6 +5,7 @@ import {
     calculateSchedulePreferenceScore,
     EventMember,
     findMatchingPreferredHourRange,
+    selectPreferredAndFallbackScores,
     SchedulePreferenceSchema,
     selectDiverseTopN,
 } from "../schedule-calculator";
@@ -596,5 +597,241 @@ describe("selectDiverseTopN", () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].score).toBe(13);
+    });
+});
+
+describe("selectPreferredAndFallbackScores", () => {
+    const createScore = (
+        start: string,
+        end: string,
+        required: string[],
+        score: number,
+    ) => ({
+        timeRange: {
+            start: new Date(start),
+            end: new Date(end),
+        },
+        availableMemberIds: { required, optional: [] },
+        score,
+    });
+
+    it("should return fallback candidates only when they improve required member availability", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T08:00:00.000Z",
+                "2026-02-27T09:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 17:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.preferred[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T03:00:00.000Z",
+        );
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T08:00:00.000Z",
+        );
+    });
+
+    it("should not return fallback candidates that are far from the selected UI hour range", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should include fallback candidates exactly three hours after the selected UI hour range", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T09:00:00.000Z",
+                "2026-02-27T10:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 18:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T09:00:00.000Z",
+        );
+    });
+
+    it("should include fallback candidates that start at 22:00", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 19:00
+            createScore(
+                "2026-02-27T13:00:00.000Z",
+                "2026-02-27T14:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 22:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 18, end: 22 }],
+            2,
+        );
+
+        expect(result.fallback).toHaveLength(1);
+        expect(result.fallback[0].timeRange.start.toISOString()).toBe(
+            "2026-02-27T13:00:00.000Z",
+        );
+    });
+
+    it("should not return late-night fallback candidates", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1"],
+                10,
+            ), // JST 19:00
+            createScore(
+                "2026-02-27T17:00:00.000Z",
+                "2026-02-27T18:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 02:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 18, end: 22 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates when required member availability does not improve", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ), // JST 12:00
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                23,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(1);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates with no required member availability when preferred candidates are empty", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                [],
+                0,
+            ), // JST 19:00
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            [{ start: 12, end: 15 }],
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(0);
+        expect(result.fallback).toHaveLength(0);
+    });
+
+    it("should not return fallback candidates when no UI hour range is specified", () => {
+        const scores = [
+            createScore(
+                "2026-02-27T03:00:00.000Z",
+                "2026-02-27T04:00:00.000Z",
+                ["user1"],
+                10,
+            ),
+            createScore(
+                "2026-02-27T10:00:00.000Z",
+                "2026-02-27T11:00:00.000Z",
+                ["user1", "user2"],
+                20,
+            ),
+        ];
+
+        const result = selectPreferredAndFallbackScores(
+            scores,
+            3,
+            undefined,
+            2,
+        );
+
+        expect(result.preferred).toHaveLength(2);
+        expect(result.fallback).toHaveLength(0);
     });
 });

--- a/src/domain/schedule-calculator.ts
+++ b/src/domain/schedule-calculator.ts
@@ -14,6 +14,10 @@ export const MEMBER_REQUIRED_SCORE = 10;
 export const MEMBER_OPTIONAL_SCORE = 1;
 export const SCHEDULE_PREFERENCE_DAY_SCORE = 1;
 export const SCHEDULE_PREFERENCE_HOUR_RANGE_SCORE = 2;
+const FALLBACK_CANDIDATE_MIN_START_HOUR = 8;
+const FALLBACK_CANDIDATE_MAX_START_HOUR = 22;
+const FALLBACK_CANDIDATE_MAX_END_HOUR = FALLBACK_CANDIDATE_MAX_START_HOUR + 1;
+const FALLBACK_CANDIDATE_HOUR_RANGE_PADDING = 3;
 
 export const SCHEDULE_PREFERENCE_DAY_OF_WEEK_VALUES = [
     "sunday",
@@ -94,6 +98,11 @@ export interface TimeRangeScore {
     score: number;
 }
 
+export interface PreferredFallbackScoreSections {
+    preferred: TimeRangeScore[];
+    fallback: TimeRangeScore[];
+}
+
 /**
  * 指定された時間帯に、指定された間隔でタイムスロットを作成する。
  * @param timeRange 時間帯
@@ -151,11 +160,12 @@ export const createSlots = (
         // 時間帯フィルタ: 指定されている場合、開始時刻（JST）がいずれかの
         // 許可範囲に含まれるスロットのみ生成する
         if (allowedHourRanges) {
-            const hourJST = (currentStart.getUTCHours() + 9) % 24;
-            const isAllowed = allowedHourRanges.some(
-                (range) => hourJST >= range.start && hourJST < range.end,
-            );
-            if (!isAllowed) {
+            if (
+                !isTimeRangeStartInAllowedHourRanges(
+                    { start: currentStart, end: currentEnd },
+                    allowedHourRanges,
+                )
+            ) {
                 currentStart = new Date(
                     currentStart.getTime() + slotIntervalMs,
                 );
@@ -294,6 +304,108 @@ export const selectDiverseTopN = (
     }
 
     return selected;
+};
+
+export const selectPreferredAndFallbackScores = (
+    scores: TimeRangeScore[],
+    n: number,
+    allowedHourRanges: { start: number; end: number }[] | undefined,
+    requiredCount: number,
+): PreferredFallbackScoreSections => {
+    const hasHourRangeConstraint =
+        allowedHourRanges !== undefined && allowedHourRanges.length > 0;
+    const preferredCandidates = hasHourRangeConstraint
+        ? scores.filter((score) =>
+              isTimeRangeStartInAllowedHourRanges(
+                  score.timeRange,
+                  allowedHourRanges,
+              ),
+          )
+        : scores;
+    const preferred = selectDiverseTopN(preferredCandidates, n);
+
+    if (!hasHourRangeConstraint || requiredCount === 0) {
+        return { preferred, fallback: [] };
+    }
+
+    const maxPreferredRequiredCount =
+        preferred.length > 0
+            ? Math.max(
+                  ...preferred.map(
+                      (score) => score.availableMemberIds.required.length,
+                  ),
+              )
+            : 0;
+    const fallbackAllowedHourRanges =
+        createFallbackAllowedHourRanges(allowedHourRanges);
+    const fallbackCandidates = scores.filter(
+        (score) =>
+            !isTimeRangeStartInAllowedHourRanges(
+                score.timeRange,
+                allowedHourRanges,
+            ) &&
+            isTimeRangeStartInAllowedHourRanges(
+                score.timeRange,
+                fallbackAllowedHourRanges,
+            ) &&
+            score.availableMemberIds.required.length >
+                maxPreferredRequiredCount,
+    );
+
+    return {
+        preferred,
+        fallback: selectDiverseTopN(fallbackCandidates, n),
+    };
+};
+
+export const isTimeRangeStartInAllowedHourRanges = (
+    timeRange: TimeRange,
+    allowedHourRanges: { start: number; end: number }[] | undefined,
+): boolean => {
+    if (!allowedHourRanges || allowedHourRanges.length === 0) {
+        return true;
+    }
+
+    const hourJST = getJSTHour(timeRange.start);
+    return allowedHourRanges.some(
+        (range) => hourJST >= range.start && hourJST < range.end,
+    );
+};
+
+const createFallbackAllowedHourRanges = (
+    allowedHourRanges: { start: number; end: number }[],
+): { start: number; end: number }[] =>
+    mergeHourRanges(
+        allowedHourRanges.flatMap((range) => {
+            const start = Math.max(
+                FALLBACK_CANDIDATE_MIN_START_HOUR,
+                range.start - FALLBACK_CANDIDATE_HOUR_RANGE_PADDING,
+            );
+            const end = Math.min(
+                FALLBACK_CANDIDATE_MAX_END_HOUR,
+                range.end + FALLBACK_CANDIDATE_HOUR_RANGE_PADDING + 1,
+            );
+
+            return start < end ? [{ start, end }] : [];
+        }),
+    );
+
+const mergeHourRanges = (
+    ranges: { start: number; end: number }[],
+): { start: number; end: number }[] => {
+    const sortedRanges = [...ranges].sort((a, b) => a.start - b.start);
+    const mergedRanges: { start: number; end: number }[] = [];
+
+    for (const range of sortedRanges) {
+        const previous = mergedRanges.at(-1);
+        if (previous && range.start <= previous.end) {
+            previous.end = Math.max(previous.end, range.end);
+        } else {
+            mergedRanges.push({ ...range });
+        }
+    }
+
+    return mergedRanges;
 };
 
 const matchesPreferredDay = (

--- a/src/domain/schedule-suggestion.ts
+++ b/src/domain/schedule-suggestion.ts
@@ -1,0 +1,14 @@
+export type ScheduleSuggestionSectionKind = "preferred" | "fallback";
+
+export interface ScheduleSuggestion {
+    start: string;
+    end: string;
+    reason: string;
+}
+
+export interface ScheduleSuggestionSection {
+    kind: ScheduleSuggestionSectionKind;
+    title: string;
+    description: string;
+    suggestions: ScheduleSuggestion[];
+}


### PR DESCRIPTION
## 概要

PR3.6（#273）の上に積んだ stacked PR です。

候補提示を単一の `suggestions` 配列から、希望時間帯内の候補と譲歩候補を分けた `sections` 形式へ変更しました。

## 変更内容

- `ScheduleSuggestion` / `ScheduleSuggestionSection` の共通型を追加
- スコア計算では全時間帯のスロットを生成し、後段で希望候補と譲歩候補に分割
- 希望候補はUI指定時間帯内の上位候補として表示
- 譲歩候補は以下を満たす場合だけ表示
  - UI指定時間帯外である
  - 希望候補より必須メンバー参加数が増える
  - UI指定時間帯の前後3時間以内に収まる
  - 開始時刻が8:00〜22:00の範囲内である
  - 必須メンバーが少なくとも1人以上参加できる
- 提案画面を `sections` 表示に対応
- sessionStorageに旧 `suggestions` 形式が残っていても、希望候補セクションへ変換して表示できるようにした
- domainテストで譲歩候補の抽出条件を追加検証

## 補足

このPRでは、深夜の譲歩候補が増えないように、譲歩候補にも時間帯のガードを入れています。

## 確認

- `corepack pnpm exec vitest run src/domain/__tests__/schedule-calculator.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule suggestions are now shown in grouped sections, making it easier to compare preferred and fallback options.
  * The schedule picker now handles both newer grouped results and older saved suggestions for smoother continuity.

* **Bug Fixes**
  * Improved no-results handling so the app correctly shows an empty state when no suggestions are available.
  * Confirmation now uses the selected suggestion from the full combined list, keeping selection behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->