### PR TITLE
feat: 候補に参加可能者と曜日を表示

### DIFF
--- a/src/app/(auth)/ai-suggest/page.tsx
+++ b/src/app/(auth)/ai-suggest/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { ja } from "date-fns/locale";
 import { Button } from "@/components/ui/button";
 import { formatToJST } from "@/lib/date";
 import { createEventAction } from "@/app/(auth)/create-event/actions";
@@ -166,6 +167,11 @@ export default function AISuggestPage() {
                                                     start,
                                                     "yyyy/MM/dd",
                                                 );
+                                                const dayOfWeek = formatToJST(
+                                                    start,
+                                                    "E",
+                                                    { locale: ja },
+                                                );
                                                 const startTime = formatToJST(
                                                     start,
                                                     "HH:mm",
@@ -209,9 +215,16 @@ export default function AISuggestPage() {
                                                         }`}
                                                     >
                                                         <p className="text-black font-bold text-center text-xl">
-                                                            {dateStr}{" "}
+                                                            {dateStr} (
+                                                            {dayOfWeek}){" "}
                                                             {startTime}～
                                                             {endTime}
+                                                        </p>
+                                                        <p className="text-gray-700 text-sm text-center mt-2">
+                                                            参加可能者:{" "}
+                                                            {formatAvailableMemberNames(
+                                                                s,
+                                                            )}
                                                         </p>
                                                         <p className="text-gray-600 text-sm text-center mt-2">
                                                             {s.reason}
@@ -259,7 +272,7 @@ function normalizeSuggestionSections(
     }
 
     if (Array.isArray(value.sections) && value.sections.every(isSection)) {
-        return value.sections;
+        return value.sections.map(normalizeSection);
     }
 
     if (
@@ -271,7 +284,7 @@ function normalizeSuggestionSections(
                 kind: "preferred",
                 title: "希望時間帯の候補",
                 description: "入力内容と選択した時間帯に沿った候補です。",
-                suggestions: value.suggestions,
+                suggestions: value.suggestions.map(normalizeSuggestion),
             },
         ];
     }
@@ -279,7 +292,21 @@ function normalizeSuggestionSections(
     return null;
 }
 
-function isSection(value: unknown): value is ScheduleSuggestionSection {
+type StoredScheduleSuggestion = Omit<
+    ScheduleSuggestion,
+    "availableMemberNames"
+> & {
+    availableMemberNames?: string[];
+};
+
+type StoredScheduleSuggestionSection = Omit<
+    ScheduleSuggestionSection,
+    "suggestions"
+> & {
+    suggestions: StoredScheduleSuggestion[];
+};
+
+function isSection(value: unknown): value is StoredScheduleSuggestionSection {
     return (
         isObject(value) &&
         (value.kind === "preferred" || value.kind === "fallback") &&
@@ -290,13 +317,42 @@ function isSection(value: unknown): value is ScheduleSuggestionSection {
     );
 }
 
-function isSuggestion(value: unknown): value is ScheduleSuggestion {
+function isSuggestion(value: unknown): value is StoredScheduleSuggestion {
     return (
         isObject(value) &&
         isParseableDateString(value.start) &&
         isParseableDateString(value.end) &&
-        typeof value.reason === "string"
+        typeof value.reason === "string" &&
+        (value.availableMemberNames === undefined ||
+            (Array.isArray(value.availableMemberNames) &&
+                value.availableMemberNames.every(
+                    (name): name is string => typeof name === "string",
+                )))
     );
+}
+
+function normalizeSection(
+    section: StoredScheduleSuggestionSection,
+): ScheduleSuggestionSection {
+    return {
+        ...section,
+        suggestions: section.suggestions.map(normalizeSuggestion),
+    };
+}
+
+function normalizeSuggestion(
+    suggestion: StoredScheduleSuggestion,
+): ScheduleSuggestion {
+    return {
+        ...suggestion,
+        availableMemberNames: suggestion.availableMemberNames ?? [],
+    };
+}
+
+function formatAvailableMemberNames(suggestion: ScheduleSuggestion): string {
+    return suggestion.availableMemberNames.length > 0
+        ? suggestion.availableMemberNames.join("、")
+        : "情報なし";
 }
 
 function isValidSession(value: unknown): value is EventSession {

--- a/src/app/(auth)/create-event/actions.ts
+++ b/src/app/(auth)/create-event/actions.ts
@@ -175,6 +175,7 @@ export async function getScheduleSuggestionsAction(
                 suggestionScores,
                 requiredCount,
                 schedulePreference,
+                members,
             ),
         };
     } catch (error) {
@@ -266,6 +267,7 @@ const createSuggestionSections = (
     },
     requiredCount: number,
     schedulePreference: SchedulePreference | undefined,
+    members: EventMember[],
 ): ScheduleSuggestionSection[] => {
     const sections: ScheduleSuggestionSection[] = [
         {
@@ -278,6 +280,7 @@ const createSuggestionSections = (
                     requiredCount,
                     schedulePreference,
                     "preferred",
+                    members,
                 ),
             ),
         },
@@ -295,6 +298,7 @@ const createSuggestionSections = (
                     requiredCount,
                     schedulePreference,
                     "fallback",
+                    members,
                 ),
             ),
         });
@@ -308,6 +312,7 @@ const createSuggestion = (
     requiredCount: number,
     schedulePreference: SchedulePreference | undefined,
     sectionKind: ScheduleSuggestionSectionKind,
+    members: EventMember[],
 ): ScheduleSuggestion => ({
     start: score.timeRange.start.toISOString(),
     end: score.timeRange.end.toISOString(),
@@ -317,7 +322,22 @@ const createSuggestion = (
         schedulePreference,
         sectionKind,
     ),
+    availableMemberNames: getAvailableMemberNames(score, members),
 });
+
+const getAvailableMemberNames = (
+    score: TimeRangeScore,
+    members: EventMember[],
+): string[] => {
+    const availableMemberIds = new Set([
+        ...score.availableMemberIds.required,
+        ...score.availableMemberIds.optional,
+    ]);
+
+    return members
+        .filter((member) => availableMemberIds.has(member.uid))
+        .map((member) => member.name);
+};
 
 export async function createEventAction(
     groupId: string,

--- a/src/domain/schedule-suggestion.ts
+++ b/src/domain/schedule-suggestion.ts
@@ -4,6 +4,7 @@ export interface ScheduleSuggestion {
     start: string;
     end: string;
     reason: string;
+    availableMemberNames: string[];
 }
 
 export interface ScheduleSuggestionSection {


### PR DESCRIPTION
## 概要

日程提案の候補カードに、曜日と参加可能者を表示するようにしました。

## 変更内容

- 日時表示を `日付 (曜日) 時間` の形式に変更
  - 例: `2026/07/13 (月) 12:00〜14:00`
- 候補ごとに参加可能な必須・任意メンバーの表示名を追加
- 既にブラウザへ保存されている古い候補データに参加可能者情報がない場合も、提案画面が壊れず `情報なし` と表示されるように対応

## 確認

- `corepack pnpm typecheck`
- `corepack pnpm test`
- `corepack pnpm lint`
- 実際の提案画面にサンプル候補を表示してスクリーンショット確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule suggestions now display the day of the week in Japanese.
  * Added a “参加可能者” section showing members available for each suggested time.
  * Suggestions without availability details display “情報なし.”

* **Bug Fixes**
  * Improved session restoration by validating and normalizing saved suggestion data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->